### PR TITLE
Add XMLTV template validation

### DIFF
--- a/template_check.go
+++ b/template_check.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"text/template"
+)
+
+// Validate the embedded XMLTV template before any network scraping begins.
+// This prevents a syntax error from being discovered only after a long scrape.
+func init() {
+	if _, err := template.ParseFS(guideTmplFS, "guide.tmpl"); err != nil {
+		panic(fmt.Sprintf("invalid embedded guide template: %v", err))
+	}
+}


### PR DESCRIPTION
# Validate XMLTV template before scraping

## Summary

Validate the embedded `guide.tmpl` during startup instead of waiting until the end of a scrape to discover template syntax errors.

## Why

The guide template is currently parsed when XMLTV rendering begins. A syntax error therefore is not reported until after the full Gracenote scrape and enrichment work has already completed.

This adds a small startup validation so invalid templates fail immediately while leaving the existing render-time parsing behavior unchanged.

## Scope

* Adds one small startup validation file.
* No changes to scraping, enrichment, caching, or generated XMLTV when the template is valid.
