### PR TITLE
Improve Gracenote grid resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 tmdb_cache.json
 tvlogo_cache.json
 guide_cache.json
+grid_cache/
 image_cache/
 demo.gif
 

--- a/web/grid_cache.go
+++ b/web/grid_cache.go
@@ -1,0 +1,140 @@
+package web
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var gridCacheRoot = "grid_cache"
+
+type cachedGrid struct {
+	SavedAt time.Time    `json:"saved_at"`
+	Source  GuideSource  `json:"source"`
+	Time    int64        `json:"time"`
+	Grid    GridResponse `json:"grid"`
+}
+
+func gridSourceKey(source GuideSource) string {
+	parts := []string{
+		source.Country,
+		source.ZipCode,
+		source.Headend,
+		source.LineupID,
+		source.Device,
+		source.Language,
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return hex.EncodeToString(sum[:8])
+}
+
+func gridCachePath(source GuideSource, gridTime int64) string {
+	return filepath.Join(gridCacheRoot, gridSourceKey(source), fmt.Sprintf("%d.json", gridTime))
+}
+
+func saveGridCache(gridTime int64, source GuideSource, grid *GridResponse) error {
+	if grid == nil {
+		return fmt.Errorf("cannot cache nil grid")
+	}
+
+	path := gridCachePath(source, gridTime)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create grid cache directory: %w", err)
+	}
+
+	data, err := json.Marshal(cachedGrid{
+		SavedAt: time.Now().UTC(),
+		Source:  source,
+		Time:    gridTime,
+		Grid:    *grid,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal grid cache: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, "grid-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create grid cache temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmpName)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write grid cache temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync grid cache temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("close grid cache temp file: %w", err)
+	}
+	if err := os.Chmod(tmpName, 0644); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("chmod grid cache temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("replace grid cache file: %w", err)
+	}
+	return nil
+}
+
+func loadGridCache(gridTime int64, source GuideSource) (*GridResponse, time.Duration, error) {
+	path := gridCachePath(source, gridTime)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, 0, fmt.Errorf("read grid cache: %w", err)
+	}
+
+	var cached cachedGrid
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil, 0, fmt.Errorf("decode grid cache: %w", err)
+	}
+	if cached.Source != source {
+		return nil, 0, fmt.Errorf("grid cache source mismatch")
+	}
+	if cached.Time != gridTime {
+		return nil, 0, fmt.Errorf("grid cache time mismatch: got %d, want %d", cached.Time, gridTime)
+	}
+	return &cached.Grid, time.Since(cached.SavedAt), nil
+}
+
+func pruneGridCache(source GuideSource, cutoff time.Time) error {
+	dir := filepath.Join(gridCacheRoot, gridSourceKey(source))
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read grid cache directory: %w", err)
+	}
+
+	cutoffUnix := cutoff.Unix()
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		stamp := strings.TrimSuffix(entry.Name(), ".json")
+		gridTime, err := strconv.ParseInt(stamp, 10, 64)
+		if err != nil || gridTime >= cutoffUnix {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove old grid cache %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}

--- a/web/web.go
+++ b/web/web.go
@@ -8,14 +8,19 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/daniel-widrick/GraceNoteScraper/util"
 )
 
-const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
+const (
+	userAgent       = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
+	gridMaxAttempts = 4
+)
 
-// JSON response structs matching the Gracenote grid API
+var gridRetryDelays = []time.Duration{2 * time.Second, 5 * time.Second, 10 * time.Second}
+
 type GridResponse struct {
 	Channels []JSONChannel `json:"channels"`
 }
@@ -60,28 +65,75 @@ type Preferences struct {
 	Language string
 }
 
+type GuideSource struct {
+	Country  string `json:"country"`
+	ZipCode  string `json:"zip_code"`
+	Headend  string `json:"headend"`
+	LineupID string `json:"lineup_id"`
+	Device   string `json:"device"`
+	Language string `json:"language"`
+}
+
+func currentPreferences() Preferences {
+	return Preferences{
+		Country:  util.GetEnv("GN_COUNTRY", "USA"),
+		ZipCode:  util.GetEnv("GN_ZIPCODE", "13490"),
+		Headend:  util.GetEnv("GN_HEADEND", "lineupId"),
+		LineupId: util.GetEnv("GN_LINEUP", "USA-lineupId-DEFAULT"),
+		Device:   util.GetEnv("GN_DEVICE", "-"),
+		Language: util.GetEnv("GN_LANGUAGE", "en-us"),
+	}
+}
+
+func (p Preferences) Source() GuideSource {
+	return GuideSource{Country: p.Country, ZipCode: p.ZipCode, Headend: p.Headend, LineupID: p.LineupId, Device: p.Device, Language: p.Language}
+}
+
 type Client struct {
 	*http.Client
 	pref Preferences
 }
 
-func (c *Client) GetDataByTime(t int64) (*GridResponse, error) {
-	log.Printf("headendId=%s lineupId=%s zipCode=%s", c.pref.Headend, c.pref.LineupId, c.pref.ZipCode)
+func (c *Client) Source() GuideSource {
+	return c.pref.Source()
+}
 
+func (c *Client) GetDataByTime(t int64) (*GridResponse, error) {
+	var lastErr error
+	for attempt := 1; attempt <= gridMaxAttempts; attempt++ {
+		grid, err := c.getDataByTimeOnce(t)
+		if err == nil {
+			if attempt > 1 {
+				log.Printf("Gracenote grid time=%d succeeded on attempt %d/%d", t, attempt, gridMaxAttempts)
+			}
+			if err := saveGridCache(t, c.Source(), grid); err != nil {
+				log.Printf("Gracenote grid cache: failed to save time=%d: %v", t, err)
+			}
+			return grid, nil
+		}
+		lastErr = err
+		if attempt == gridMaxAttempts {
+			break
+		}
+		delay := gridRetryDelays[attempt-1]
+		log.Printf("Gracenote grid time=%d attempt %d/%d failed: %v; retrying in %s", t, attempt, gridMaxAttempts, err, delay)
+		time.Sleep(delay)
+	}
+
+	fallback, age, err := loadGridCache(t, c.Source())
+	if err == nil {
+		log.Printf("Gracenote grid time=%d exhausted %d attempts; using cached raw grid (%s old)", t, gridMaxAttempts, age.Round(time.Second))
+		return fallback, nil
+	}
+	return nil, fmt.Errorf("Gracenote grid time=%d failed after %d attempts (%v); cached fallback unavailable: %w", t, gridMaxAttempts, lastErr, err)
+}
+
+func (c *Client) getDataByTimeOnce(t int64) (*GridResponse, error) {
+	log.Printf("headendId=%s lineupId=%s zipCode=%s", c.pref.Headend, c.pref.LineupId, c.pref.ZipCode)
 	params := url.Values{
-		"aid":          {"orbebb"},
-		"lineupId":     {c.pref.LineupId},
-		"timespan":     {"6"},
-		"headendId":    {c.pref.Headend},
-		"country":      {c.pref.Country},
-		"device":       {c.pref.Device},
-		"postalCode":   {c.pref.ZipCode},
-		"isOverride":   {"true"},
-		"time":         {fmt.Sprintf("%d", t)},
-		"timezone":     {""},
-		"pref":         {"16,256"},
-		"userId":       {"-"},
-		"languagecode": {c.pref.Language},
+		"aid": {"orbebb"}, "lineupId": {c.pref.LineupId}, "timespan": {"6"}, "headendId": {c.pref.Headend},
+		"country": {c.pref.Country}, "device": {c.pref.Device}, "postalCode": {c.pref.ZipCode}, "isOverride": {"true"},
+		"time": {fmt.Sprintf("%d", t)}, "timezone": {""}, "pref": {"16,256"}, "userId": {"-"}, "languagecode": {c.pref.Language},
 	}
 	gridURL := "https://tvlistings.gracenote.com/api/grid?" + params.Encode()
 	log.Printf("Fetching: %s", gridURL)
@@ -96,12 +148,14 @@ func (c *Client) GetDataByTime(t int64) (*GridResponse, error) {
 		return nil, fmt.Errorf("GetDataByTime request failed: %w", err)
 	}
 	defer resp.Body.Close()
-
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("guide API returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read guide body: %w", err)
 	}
-
 	var grid GridResponse
 	if err := json.Unmarshal(b, &grid); err != nil {
 		return nil, fmt.Errorf("unable to parse guide JSON: %w", err)
@@ -115,28 +169,17 @@ func NewClient() *Client {
 		log.Fatalf("Unable to create cookie storage for http client: %v", err)
 		return nil
 	}
-	return &Client{
-		Client: &http.Client{
-			Jar:     jar,
-			Timeout: 15 * time.Second,
-			Transport: &headerTransport{
-				rt: http.DefaultTransport,
-			},
-		},
-		pref: Preferences{
-			Country:  util.GetEnv("GN_COUNTRY", "USA"),
-			ZipCode:  util.GetEnv("GN_ZIPCODE", "13490"),
-			Headend:  util.GetEnv("GN_HEADEND", "lineupId"),
-			LineupId: util.GetEnv("GN_LINEUP", "USA-lineupId-DEFAULT"),
-			Device:   util.GetEnv("GN_DEVICE", "-"),
-			Language: util.GetEnv("GN_LANGUAGE", "en-us"),
-		},
+	client := &Client{
+		Client: &http.Client{Jar: jar, Timeout: 15 * time.Second, Transport: &headerTransport{rt: http.DefaultTransport}},
+		pref: currentPreferences(),
 	}
+	if err := pruneGridCache(client.Source(), time.Now().UTC().Add(-48*time.Hour)); err != nil {
+		log.Printf("Gracenote grid cache: prune failed: %v", err)
+	}
+	return client
 }
 
-type headerTransport struct {
-	rt http.RoundTripper
-}
+type headerTransport struct{ rt http.RoundTripper }
 
 func (t *headerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", userAgent)

--- a/web/web.go
+++ b/web/web.go
@@ -171,7 +171,7 @@ func NewClient() *Client {
 	}
 	client := &Client{
 		Client: &http.Client{Jar: jar, Timeout: 15 * time.Second, Transport: &headerTransport{rt: http.DefaultTransport}},
-		pref: currentPreferences(),
+		pref:   currentPreferences(),
 	}
 	if err := pruneGridCache(client.Source(), time.Now().UTC().Add(-48*time.Hour)); err != nil {
 		log.Printf("Gracenote grid cache: prune failed: %v", err)

--- a/web/web_fallback_test.go
+++ b/web/web_fallback_test.go
@@ -29,16 +29,34 @@ func TestGetDataByTimeRetriesTransientFailure(t *testing.T) {
 	originalDelays := gridRetryDelays
 	gridRetryDelays = []time.Duration{0, 0, 0}
 	defer func() { gridRetryDelays = originalDelays }()
+
 	attempts := 0
-	client := &Client{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		attempts++
-		if attempts < 3 { return nil, errors.New("temporary timeout") }
-		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: io.NopCloser(strings.NewReader(`{"channels":[]}`)), Header: make(http.Header)}, nil
-	})}, pref: testPreferences()}
+	client := &Client{
+		Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 3 {
+				return nil, errors.New("temporary timeout")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader("{\"channels\":[]}")),
+				Header:     make(http.Header),
+			}, nil
+		})},
+		pref: testPreferences(),
+	}
+
 	gridTime := time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC).Unix()
-	if _, err := client.GetDataByTime(gridTime); err != nil { t.Fatalf("GetDataByTime: %v", err) }
-	if attempts != 3 { t.Fatalf("attempts = %d, want 3", attempts) }
-	if _, _, err := loadGridCache(gridTime, client.Source()); err != nil { t.Fatalf("cache missing: %v", err) }
+	if _, err := client.GetDataByTime(gridTime); err != nil {
+		t.Fatalf("GetDataByTime: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("attempts = %d, want 3", attempts)
+	}
+	if _, _, err := loadGridCache(gridTime, client.Source()); err != nil {
+		t.Fatalf("cache missing: %v", err)
+	}
 }
 
 func TestGetDataByTimeFallsBackToCachedRawGrid(t *testing.T) {
@@ -46,16 +64,42 @@ func TestGetDataByTimeFallsBackToCachedRawGrid(t *testing.T) {
 	originalDelays := gridRetryDelays
 	gridRetryDelays = []time.Duration{0, 0, 0}
 	defer func() { gridRetryDelays = originalDelays }()
+
 	prefs := testPreferences()
 	gridTime := time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC).Unix()
-	cached := &GridResponse{Channels: []JSONChannel{{ChannelID: "10139", ChannelNo: "102", CallSign: "CNBC", Events: []JSONEvent{{StartTime: "2026-07-25T07:00:00Z", EndTime: "2026-07-25T08:00:00Z", Program: JSONProgram{ID: "EP123", Title: "Morning Business"}}}}}
-	if err := saveGridCache(gridTime, prefs.Source(), cached); err != nil { t.Fatalf("saveGridCache: %v", err) }
+	cached := &GridResponse{Channels: []JSONChannel{{
+		ChannelID: "10139",
+		ChannelNo: "102",
+		CallSign:  "CNBC",
+		Events: []JSONEvent{{
+			StartTime: "2026-07-25T07:00:00Z",
+			EndTime:   "2026-07-25T08:00:00Z",
+			Program:   JSONProgram{ID: "EP123", Title: "Morning Business"},
+		}},
+	}}}
+	if err := saveGridCache(gridTime, prefs.Source(), cached); err != nil {
+		t.Fatalf("saveGridCache: %v", err)
+	}
+
 	attempts := 0
-	client := &Client{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { attempts++; return nil, errors.New("upstream unavailable") })}, pref: prefs}
+	client := &Client{
+		Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			attempts++
+			return nil, errors.New("upstream unavailable")
+		})},
+		pref: prefs,
+	}
+
 	grid, err := client.GetDataByTime(gridTime)
-	if err != nil { t.Fatalf("fallback failed: %v", err) }
-	if attempts != gridMaxAttempts { t.Fatalf("attempts = %d, want %d", attempts, gridMaxAttempts) }
-	if len(grid.Channels) != 1 || grid.Channels[0].Events[0].Program.Title != "Morning Business" { t.Fatalf("unexpected cached grid: %#v", grid) }
+	if err != nil {
+		t.Fatalf("fallback failed: %v", err)
+	}
+	if attempts != gridMaxAttempts {
+		t.Fatalf("attempts = %d, want %d", attempts, gridMaxAttempts)
+	}
+	if len(grid.Channels) != 1 || grid.Channels[0].Events[0].Program.Title != "Morning Business" {
+		t.Fatalf("unexpected cached grid: %#v", grid)
+	}
 }
 
 func TestGridCacheIsScopedByGuideSource(t *testing.T) {
@@ -64,9 +108,16 @@ func TestGridCacheIsScopedByGuideSource(t *testing.T) {
 	source := testPreferences().Source()
 	other := source
 	other.LineupID = "OTHER-LINEUP"
-	if gridCachePath(source, gridTime) == gridCachePath(other, gridTime) { t.Fatal("different lineups share cache path") }
-	if err := saveGridCache(gridTime, source, &GridResponse{}); err != nil { t.Fatalf("saveGridCache: %v", err) }
-	if _, _, err := loadGridCache(gridTime, other); err == nil { t.Fatal("different lineup reused cached grid") }
+
+	if gridCachePath(source, gridTime) == gridCachePath(other, gridTime) {
+		t.Fatal("different lineups share cache path")
+	}
+	if err := saveGridCache(gridTime, source, &GridResponse{}); err != nil {
+		t.Fatalf("saveGridCache: %v", err)
+	}
+	if _, _, err := loadGridCache(gridTime, other); err == nil {
+		t.Fatal("different lineup reused cached grid")
+	}
 }
 
 func TestPruneGridCacheRemovesExpiredSlots(t *testing.T) {
@@ -74,9 +125,20 @@ func TestPruneGridCacheRemovesExpiredSlots(t *testing.T) {
 	source := testPreferences().Source()
 	oldTime := time.Now().UTC().Add(-72 * time.Hour).Unix()
 	newTime := time.Now().UTC().Add(24 * time.Hour).Unix()
-	if err := saveGridCache(oldTime, source, &GridResponse{}); err != nil { t.Fatalf("save old grid: %v", err) }
-	if err := saveGridCache(newTime, source, &GridResponse{}); err != nil { t.Fatalf("save new grid: %v", err) }
-	if err := pruneGridCache(source, time.Now().UTC().Add(-48*time.Hour)); err != nil { t.Fatalf("pruneGridCache: %v", err) }
-	if _, err := os.Stat(gridCachePath(source, oldTime)); !os.IsNotExist(err) { t.Fatalf("old grid not pruned: %v", err) }
-	if _, err := os.Stat(gridCachePath(source, newTime)); err != nil { t.Fatalf("new grid incorrectly pruned: %v", err) }
+
+	if err := saveGridCache(oldTime, source, &GridResponse{}); err != nil {
+		t.Fatalf("save old grid: %v", err)
+	}
+	if err := saveGridCache(newTime, source, &GridResponse{}); err != nil {
+		t.Fatalf("save new grid: %v", err)
+	}
+	if err := pruneGridCache(source, time.Now().UTC().Add(-48*time.Hour)); err != nil {
+		t.Fatalf("pruneGridCache: %v", err)
+	}
+	if _, err := os.Stat(gridCachePath(source, oldTime)); !os.IsNotExist(err) {
+		t.Fatalf("old grid not pruned: %v", err)
+	}
+	if _, err := os.Stat(gridCachePath(source, newTime)); err != nil {
+		t.Fatalf("new grid incorrectly pruned: %v", err)
+	}
 }

--- a/web/web_fallback_test.go
+++ b/web/web_fallback_test.go
@@ -1,0 +1,82 @@
+package web
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func useTempGridCache(t *testing.T) {
+	original := gridCacheRoot
+	gridCacheRoot = t.TempDir()
+	t.Cleanup(func() { gridCacheRoot = original })
+}
+
+func testPreferences() Preferences {
+	return Preferences{Country: "USA", ZipCode: "11743", Headend: "NY67791", LineupId: "NY67791-X", Device: "X", Language: "en"}
+}
+
+func TestGetDataByTimeRetriesTransientFailure(t *testing.T) {
+	useTempGridCache(t)
+	originalDelays := gridRetryDelays
+	gridRetryDelays = []time.Duration{0, 0, 0}
+	defer func() { gridRetryDelays = originalDelays }()
+	attempts := 0
+	client := &Client{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		if attempts < 3 { return nil, errors.New("temporary timeout") }
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: io.NopCloser(strings.NewReader(`{"channels":[]}`)), Header: make(http.Header)}, nil
+	})}, pref: testPreferences()}
+	gridTime := time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC).Unix()
+	if _, err := client.GetDataByTime(gridTime); err != nil { t.Fatalf("GetDataByTime: %v", err) }
+	if attempts != 3 { t.Fatalf("attempts = %d, want 3", attempts) }
+	if _, _, err := loadGridCache(gridTime, client.Source()); err != nil { t.Fatalf("cache missing: %v", err) }
+}
+
+func TestGetDataByTimeFallsBackToCachedRawGrid(t *testing.T) {
+	useTempGridCache(t)
+	originalDelays := gridRetryDelays
+	gridRetryDelays = []time.Duration{0, 0, 0}
+	defer func() { gridRetryDelays = originalDelays }()
+	prefs := testPreferences()
+	gridTime := time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC).Unix()
+	cached := &GridResponse{Channels: []JSONChannel{{ChannelID: "10139", ChannelNo: "102", CallSign: "CNBC", Events: []JSONEvent{{StartTime: "2026-07-25T07:00:00Z", EndTime: "2026-07-25T08:00:00Z", Program: JSONProgram{ID: "EP123", Title: "Morning Business"}}}}}
+	if err := saveGridCache(gridTime, prefs.Source(), cached); err != nil { t.Fatalf("saveGridCache: %v", err) }
+	attempts := 0
+	client := &Client{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) { attempts++; return nil, errors.New("upstream unavailable") })}, pref: prefs}
+	grid, err := client.GetDataByTime(gridTime)
+	if err != nil { t.Fatalf("fallback failed: %v", err) }
+	if attempts != gridMaxAttempts { t.Fatalf("attempts = %d, want %d", attempts, gridMaxAttempts) }
+	if len(grid.Channels) != 1 || grid.Channels[0].Events[0].Program.Title != "Morning Business" { t.Fatalf("unexpected cached grid: %#v", grid) }
+}
+
+func TestGridCacheIsScopedByGuideSource(t *testing.T) {
+	useTempGridCache(t)
+	gridTime := time.Date(2026, 7, 25, 6, 0, 0, 0, time.UTC).Unix()
+	source := testPreferences().Source()
+	other := source
+	other.LineupID = "OTHER-LINEUP"
+	if gridCachePath(source, gridTime) == gridCachePath(other, gridTime) { t.Fatal("different lineups share cache path") }
+	if err := saveGridCache(gridTime, source, &GridResponse{}); err != nil { t.Fatalf("saveGridCache: %v", err) }
+	if _, _, err := loadGridCache(gridTime, other); err == nil { t.Fatal("different lineup reused cached grid") }
+}
+
+func TestPruneGridCacheRemovesExpiredSlots(t *testing.T) {
+	useTempGridCache(t)
+	source := testPreferences().Source()
+	oldTime := time.Now().UTC().Add(-72 * time.Hour).Unix()
+	newTime := time.Now().UTC().Add(24 * time.Hour).Unix()
+	if err := saveGridCache(oldTime, source, &GridResponse{}); err != nil { t.Fatalf("save old grid: %v", err) }
+	if err := saveGridCache(newTime, source, &GridResponse{}); err != nil { t.Fatalf("save new grid: %v", err) }
+	if err := pruneGridCache(source, time.Now().UTC().Add(-48*time.Hour)); err != nil { t.Fatalf("pruneGridCache: %v", err) }
+	if _, err := os.Stat(gridCachePath(source, oldTime)); !os.IsNotExist(err) { t.Fatalf("old grid not pruned: %v", err) }
+	if _, err := os.Stat(gridCachePath(source, newTime)); err != nil { t.Fatalf("new grid incorrectly pruned: %v", err) }
+}


### PR DESCRIPTION
# Improve Gracenote grid resilience

## Summary

Retry failed six-hour Gracenote grid requests and fall back to the most recent cached raw response for the exact same lineup and grid time.

## Changes

* Retry each grid request up to four total attempts with 2s, 5s, and 10s backoff.
* Treat non-2xx HTTP responses as request failures.
* Cache successful raw Gracenote grid responses atomically.
* Scope cached grids by country, ZIP code, headend, lineup, device, and language.
* Fall back only to the exact requested six-hour grid from the same source.
* Prune expired past grid-cache entries.
* Add tests for transient retries, cached fallback, lineup isolation, and cache pruning.
* Ignore the generated `grid_cache/` directory.

## Why

A temporary timeout currently causes that six-hour guide segment to be skipped while the rest of the scrape continues. The resulting XMLTV can therefore be missing several thousand programme entries even though a previous scrape contained valid data for the affected window.

This keeps successful grids fresh while allowing only failed windows to reuse previously fetched data, without mixing data between different lineups.
