### PR TITLE
Add ZIP-based provider setup and guide-build progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,16 @@
-# GraceNote / TMS headend configuration
-GN_HEADEND = "lineupId"
-GN_LINEUP = "USA-lineupId-DEFAULT"
+# GraceNote / TMS lineup configuration
+# Leave GN_HEADEND, GN_LINEUP, and GN_ZIPCODE empty to choose a provider at
+# http://<your-host>:8080/setup. Complete GN_* settings remain supported as a
+# bootstrap for existing deployments.
+GN_HEADEND = ""
+GN_LINEUP = ""
 GN_COUNTRY = "USA"
-GN_ZIPCODE = "00000"
-GN_LANGUAGE = "en"
+GN_ZIPCODE = ""
+GN_LANGUAGE = "en-us"
 GN_DEVICE = "-"
+
+# Path for the non-secret lineup selection saved by /setup.
+CONFIG_PATH = "config.json"
 
 # TMDB read-access token (optional — enables poster images and metadata)
 # Get one at https://www.themoviedb.org/settings/api

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.exe
 .env
+config.json
 *.xmltv
 tmdb_cache.json
 tvlogo_cache.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,20 +23,21 @@ docker compose up -d --build
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o gracenotescraper .
 ```
 
-There are no test files in this project.
+Run `go test ./...` for the setup, configuration, and provider-client tests.
 
 ## Architecture
 
-The binary is a single Go process that scrapes GraceNote/TMS for 14 days of TV listings and serves the data as XMLTV over HTTP. The main orchestration lives entirely in `main.go`.
+The binary is a single Go process that scrapes GraceNote/TMS for 14 days of TV listings and serves the data as XMLTV over HTTP. Runtime orchestration lives in `main.go`; setup handlers live in `setup.go` and persisted configuration lives in `appconfig/`.
 
 **Data flow:**
 
-1. `web.Client.GetDataByTime` fetches 6-hour grid slices from the GraceNote API (`tvlistings.gracenote.com/api/grid`) — 56 slots for 14 days. A 5-second sleep separates requests. Raw JSON types live in `web/web.go`.
-2. `guide.ConvertChannel` / `guide.ConvertEvent` translate the raw JSON into `guide.TVGuide` (internal canonical types). The `guide.tmpl` template renders these to XMLTV. Both `index.html` and `guide.tmpl` are embedded at build time via `//go:embed`.
-3. `tmdb.Client.Lookup` enriches programs (poster images, ratings, overview, year) via TMDB search API. Deduplicates by `(title, isMovie)` before hitting the API. Rate-limited to ~4 req/sec.
-4. `tvlogo.Client.Resolve` replaces Gracenote channel icons with verified PNGs from `github.com/tv-logo/tv-logos`. Generates candidate URL slugs from callsign/affiliate name and HEAD-checks each (rate-limited to ~5 req/sec).
-5. `fixDeadImageURLs` rewrites `zap2it.tmsimg.com` → `tmsimg.com` for broken Gracenote image URLs.
-6. If `BASE_URL` is set, all image URLs are rewritten to route through the local `/img` proxy endpoint.
+1. `/setup` uses `web.ProviderClient` to discover Gracenote lineups by country and postal code. `appconfig.Store` persists the selected non-secret source in `config.json`; complete legacy `GN_*` settings can bootstrap it.
+2. `web.Client.GetDataByTime` fetches 6-hour grid slices from the GraceNote API (`tvlistings.gracenote.com/api/grid`) — 56 slots for 14 days. A 5-second sleep separates requests. Raw JSON types live in `web/web.go`.
+3. `guide.ConvertChannel` / `guide.ConvertEvent` translate the raw JSON into `guide.TVGuide` (internal canonical types). The `guide.tmpl` template renders these to XMLTV. `index.html`, `setup.html`, and `guide.tmpl` are embedded at build time via `//go:embed`.
+4. `tmdb.Client.Lookup` enriches programs (poster images, ratings, overview, year) via TMDB search API. Deduplicates by `(title, isMovie)` before hitting the API. Rate-limited to ~4 req/sec.
+5. `tvlogo.Client.Resolve` replaces Gracenote channel icons with verified PNGs from `github.com/tv-logo/tv-logos`. Generates candidate URL slugs from callsign/affiliate name and HEAD-checks each (rate-limited to ~5 req/sec).
+6. `fixDeadImageURLs` rewrites `zap2it.tmsimg.com` → `tmsimg.com` for broken Gracenote image URLs.
+7. If `BASE_URL` is set, all image URLs are rewritten to route through the local `/img` proxy endpoint.
 
 **Caching layers:**
 
@@ -47,7 +48,7 @@ The binary is a single Go process that scrapes GraceNote/TMS for 14 days of TV l
 | TV logo HEAD checks | `tvlogo_cache.json` | persisted, no expiry |
 | Image proxy | `image_cache/` dir | indefinite (per-URL SHA256 key) |
 
-**Server mode startup logic:** On start, if `xmlguide.xmltv` and `guide_cache.json` both exist and the cache is under 4 hours old, the scrape is skipped. The next scrape fires when the cache would have been 24 hours old. A `sync.RWMutex`-guarded `GuideState` struct holds the live `*guide.TVGuide` and is swapped atomically after each background scrape.
+**Server mode startup logic:** The HTTP server starts even without a provider so `/setup` is always recoverable. `/` redirects to setup until a valid source exists. If `xmlguide.xmltv` and a source-matching `guide_cache.json` both exist and the cache is under 4 hours old, the initial scrape is skipped. Otherwise a background scrape is queued. A `sync.RWMutex`-guarded `GuideState` holds the live guide, and `appconfig.Store.WhileCurrent` prevents an old scrape from publishing after a provider change.
 
 **Jellyfin integration:** Optional. When `JELLYFIN_URL` + `JELLYFIN_API_KEY` are set, three extra routes are registered (`/api/livetv/channels`, `/api/livetv/tune`, `/api/livetv/stop`). The tune flow does a 3-step Jellyfin handshake (PlaybackInfo → LiveStreams/Open → build master.m3u8 URL) with a hardcoded 4-second delay before returning the HLS URL. Channel filter (`JELLYFIN_CHANNEL_FILTER`) reduces the guide to only channels Jellyfin has in its live TV lineup, matched by channel number.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Generate XMLTV guide data from GraceNote/TMS listings for use with Jellyfin, Ple
 - Enriches programs with TMDB poster images, ratings, descriptions, and release dates
 - Enriches channel icons via the [tv-logo/tv-logos](https://github.com/tv-logo/tv-logos) project
 - Runs as a long-lived server with automatic 24-hour refresh, or as a one-shot scrape for cron jobs
+- First-run ZIP/postal-code setup with cable, satellite, and over-the-air lineup selection
 - Guide data cached on disk — fast restarts without re-scraping
 - Automatic XMLTV file rotation with 7-day retention
 - Optional Jellyfin Live TV integration with in-browser streaming
@@ -16,12 +17,13 @@ Generate XMLTV guide data from GraceNote/TMS listings for use with Jellyfin, Ple
 
 ## Jellyfin / Plex Setup
 
-1. Run the scraper in server mode (see below)
-2. In your DVR software, add an XMLTV guide source pointing to:
+1. Run the scraper in server mode (see below).
+2. Open `http://<your-host>:8080/setup` and choose your provider lineup.
+3. When the first guide finishes building, add an XMLTV guide source in your DVR software pointing to:
    ```
    http://<your-host>:8080/xmlguide.xmltv
    ```
-3. Guide data refreshes automatically every 24 hours
+4. Guide data refreshes automatically every 24 hours.
 
 Alternatively, use `--guide-only` mode with a cron job and point your DVR software at the local `xmlguide.xmltv` file.
 
@@ -33,10 +35,10 @@ Alternatively, use `--guide-only` mode with a cron job and point your DVR softwa
    cd GraceNoteScraper
    ```
 
-2. Copy and fill in the environment file:
+2. Copy the environment file for optional integrations:
    ```sh
    cp .env.example .env
-   # Edit .env with your headend/lineup details and optional TMDB token
+   # Optionally add a TMDB token, Jellyfin settings, or legacy GN_* settings
    ```
 
 3. Start the container:
@@ -44,9 +46,11 @@ Alternatively, use `--guide-only` mode with a cron job and point your DVR softwa
    docker compose up -d
    ```
 
-4. Point your DVR software at `http://<your-host>:8080/xmlguide.xmltv`
+4. Open `http://<your-host>:8080/setup`, enter your ZIP or postal code, and choose a provider lineup.
 
-Guide data, caches, and images are persisted in a Docker volume. The container restarts automatically and refreshes guide data every 24 hours.
+5. After the first guide finishes building, point your DVR software at `http://<your-host>:8080/xmlguide.xmltv`.
+
+Setup, guide data, caches, and images are persisted in a Docker volume. The container restarts automatically and refreshes guide data every 24 hours.
 
 To view logs:
 ```sh
@@ -61,7 +65,6 @@ docker compose up -d --build
 ## Requirements
 
 - Docker and Docker Compose, **or** Go 1.25+ for building from source
-- A GraceNote/TMS headend lineup ID
 - (Optional) A [TMDB API read access token](https://www.themoviedb.org/settings/api) for poster images and metadata
 
 ## Building from Source
@@ -79,6 +82,8 @@ cp .env.example .env
 
 Scrapes once, writes `xmlguide.xmltv` to the working directory, and exits. Useful for cron-based setups where you don't need the server running.
 
+Run server mode once to save a provider through `/setup`, or provide complete legacy `GN_*` settings, before using this mode.
+
 ```sh
 ./gracenotescraper --guide-only
 ```
@@ -87,11 +92,12 @@ Scrapes once, writes `xmlguide.xmltv` to the working directory, and exits. Usefu
 
 | Variable | Description | Default |
 |---|---|---|
-| `GN_HEADEND` | GraceNote headend/lineup ID | — |
-| `GN_LINEUP` | Full lineup string | — |
+| `CONFIG_PATH` | Saved non-secret setup configuration | `config.json` |
+| `GN_HEADEND` | Legacy/bootstrap GraceNote headend ID; use with `GN_LINEUP` and `GN_ZIPCODE` | — |
+| `GN_LINEUP` | Legacy/bootstrap full lineup string | — |
 | `GN_COUNTRY` | Country code | `USA` |
-| `GN_ZIPCODE` | ZIP code for lineup | — |
-| `GN_LANGUAGE` | Language code | `en` |
+| `GN_ZIPCODE` | Legacy/bootstrap ZIP or postal code | — |
+| `GN_LANGUAGE` | Language code | `en-us` |
 | `GN_DEVICE` | Device identifier | `-` |
 | `TMDB_TOKEN` | TMDB read access token (optional) | — |
 | `BASE_URL` | Server base URL — rewrites XMLTV image URLs to use the built-in proxy cache (e.g. `http://192.168.1.50:8080`) | — |
@@ -100,10 +106,16 @@ Scrapes once, writes `xmlguide.xmltv` to the working directory, and exits. Usefu
 | `JELLYFIN_API_KEY` | Jellyfin API key | — |
 | `JELLYFIN_CHANNEL_FILTER` | Set to any non-empty value to filter guide to only Jellyfin-available channels. Requires `JELLYFIN_URL` and `JELLYFIN_API_KEY`. | — |
 
+A saved `CONFIG_PATH` selection takes precedence over legacy `GN_*` settings. Delete or move that file if you intentionally want to bootstrap from environment settings again.
+
 ## HTTP Endpoints
 
 | Endpoint | Description |
 |---|---|
+| `GET /setup` | Choose or change the active provider lineup |
+| `GET /api/setup/config` | Read the current non-secret lineup selection |
+| `GET /api/setup/providers?postalCode=...` | Find Gracenote lineups for an area |
+| `POST /api/setup/provider` | Save the selected provider and queue a fresh guide |
 | `GET /xmlguide.xmltv` | XMLTV guide data (point your DVR here) |
 | `GET /api/guide.json` | Guide data as JSON |
 | `GET /` | The Grid — built-in web UI |
@@ -115,13 +127,14 @@ Scrapes once, writes `xmlguide.xmltv` to the working directory, and exits. Usefu
 
 ## The Grid
 
-The server includes a built-in retro-styled TV guide web UI at the root URL. It auto-scrolls through your channel lineup and shows program details, posters, and metadata. Handy for a quick glance at what's on without opening your DVR app.
+The server includes a built-in retro-styled TV guide web UI at the root URL. If no provider is configured, `/` redirects to `/setup`. Once configured, the guide auto-scrolls through your channel lineup and shows program details, posters, and metadata. Handy for a quick glance at what's on without opening your DVR app.
 
 ![The Grid](https://gist.githubusercontent.com/daniel-widrick/2c52c4d023ffe75d163b4eff58263c77/raw/demo.gif)
 
 ## Project Structure
 
 ```
+appconfig/       Persisted non-secret provider configuration
 main.go          Entry point, HTTP server, scraper, image proxy
 guide/           GraceNote data types and XMLTV conversion
 web/             HTTP client for GraceNote API
@@ -129,6 +142,7 @@ tmdb/            TMDB client and cache
 tvlogo/          TV logo resolver and cache
 util/            Shared helpers
 index.html       The Grid web UI (embedded at build time)
+setup.html       Provider-selection UI (embedded at build time)
 guide.tmpl       XMLTV output template (embedded at build time)
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Generate XMLTV guide data from GraceNote/TMS listings for use with Jellyfin, Ple
 
 1. Run the scraper in server mode (see below).
 2. Open `http://<your-host>:8080/setup` and choose your provider lineup.
-3. When the first guide finishes building, add an XMLTV guide source in your DVR software pointing to:
+3. When the first guide finishes building, click the XMLTV guide URL on the setup page to copy it, or add this equivalent URL to your DVR software:
    ```
    http://<your-host>:8080/xmlguide.xmltv
    ```
@@ -48,7 +48,7 @@ Alternatively, use `--guide-only` mode with a cron job and point your DVR softwa
 
 4. Open `http://<your-host>:8080/setup`, enter your ZIP or postal code, and choose a provider lineup.
 
-5. After the first guide finishes building, point your DVR software at `http://<your-host>:8080/xmlguide.xmltv`.
+5. After the first guide finishes building, click the XMLTV guide URL shown on the setup page to copy it into your DVR software.
 
 Setup, guide data, caches, and images are persisted in a Docker volume. The container restarts automatically and refreshes guide data every 24 hours.
 

--- a/appconfig/config.go
+++ b/appconfig/config.go
@@ -1,0 +1,296 @@
+package appconfig
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/daniel-widrick/GraceNoteScraper/web"
+)
+
+const CurrentVersion = 1
+
+var (
+	countryPattern  = regexp.MustCompile(`^[A-Z]{3}$`)
+	postalPattern   = regexp.MustCompile(`^[A-Z0-9][A-Z0-9 -]{1,15}$`)
+	languagePattern = regexp.MustCompile(`^[a-z]{2,3}(?:-[a-z]{2})?$`)
+	idPattern       = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+	typePattern     = regexp.MustCompile(`^[A-Z][A-Z0-9 _-]{0,31}$`)
+)
+
+// Config is the persisted, non-secret application configuration.
+type Config struct {
+	Version   int             `json:"version"`
+	Gracenote GracenoteConfig `json:"gracenote"`
+}
+
+// GracenoteConfig identifies the active provider lineup.
+type GracenoteConfig struct {
+	Country      string `json:"country"`
+	PostalCode   string `json:"postalCode"`
+	Language     string `json:"language"`
+	ProviderType string `json:"providerType,omitempty"`
+	Device       string `json:"device"`
+	LineupID     string `json:"lineupId"`
+	ProviderName string `json:"providerName"`
+	Location     string `json:"location,omitempty"`
+	HeadendID    string `json:"headendId"`
+}
+
+func (c Config) normalized() Config {
+	c.Gracenote.Country = strings.ToUpper(strings.TrimSpace(c.Gracenote.Country))
+	c.Gracenote.PostalCode = strings.ToUpper(strings.TrimSpace(c.Gracenote.PostalCode))
+	c.Gracenote.Language = strings.ToLower(strings.TrimSpace(c.Gracenote.Language))
+	c.Gracenote.ProviderType = strings.ToUpper(strings.TrimSpace(c.Gracenote.ProviderType))
+	c.Gracenote.Device = strings.TrimSpace(c.Gracenote.Device)
+	c.Gracenote.LineupID = strings.TrimSpace(c.Gracenote.LineupID)
+	c.Gracenote.ProviderName = strings.TrimSpace(c.Gracenote.ProviderName)
+	c.Gracenote.Location = strings.TrimSpace(c.Gracenote.Location)
+	c.Gracenote.HeadendID = strings.TrimSpace(c.Gracenote.HeadendID)
+	return c
+}
+
+func ValidateLookup(country, postalCode, language string) error {
+	country = strings.ToUpper(strings.TrimSpace(country))
+	postalCode = strings.ToUpper(strings.TrimSpace(postalCode))
+	language = strings.ToLower(strings.TrimSpace(language))
+	if !countryPattern.MatchString(country) {
+		return errors.New("country must be a three-letter code")
+	}
+	if !postalPattern.MatchString(postalCode) {
+		return errors.New("postal code is invalid")
+	}
+	if !languagePattern.MatchString(language) {
+		return errors.New("language must look like en or en-us")
+	}
+	return nil
+}
+
+func (c Config) Validate() error {
+	c = c.normalized()
+	if c.Version != CurrentVersion {
+		return fmt.Errorf("unsupported configuration version %d", c.Version)
+	}
+	if !countryPattern.MatchString(c.Gracenote.Country) {
+		return errors.New("country must be a three-letter code")
+	}
+	if !postalPattern.MatchString(c.Gracenote.PostalCode) {
+		return errors.New("postal code is invalid")
+	}
+	if !languagePattern.MatchString(c.Gracenote.Language) {
+		return errors.New("language must look like en or en-us")
+	}
+	if c.Gracenote.ProviderType != "" && !typePattern.MatchString(c.Gracenote.ProviderType) {
+		return errors.New("provider type is invalid")
+	}
+	if c.Gracenote.Device != "" && !idPattern.MatchString(c.Gracenote.Device) {
+		return errors.New("provider device is invalid")
+	}
+	if !idPattern.MatchString(c.Gracenote.LineupID) {
+		return errors.New("lineup ID is invalid")
+	}
+	if !idPattern.MatchString(c.Gracenote.HeadendID) {
+		return errors.New("headend ID is invalid")
+	}
+	if c.Gracenote.ProviderName == "" || len(c.Gracenote.ProviderName) > 200 {
+		return errors.New("provider name is invalid")
+	}
+	if len(c.Gracenote.Location) > 200 {
+		return errors.New("provider location is invalid")
+	}
+	return nil
+}
+
+func (c Config) Preferences() web.Preferences {
+	c = c.normalized()
+	return web.Preferences{
+		Country:  c.Gracenote.Country,
+		ZipCode:  c.Gracenote.PostalCode,
+		Headend:  c.Gracenote.HeadendID,
+		LineupId: c.Gracenote.LineupID,
+		Device:   c.Gracenote.Device,
+		Language: c.Gracenote.Language,
+	}
+}
+
+// Fingerprint identifies every setting that changes a Gracenote grid source.
+func (c Config) Fingerprint() string {
+	p := c.Preferences()
+	value := strings.Join([]string{
+		p.Country,
+		p.ZipCode,
+		p.Headend,
+		p.LineupId,
+		p.Device,
+		p.Language,
+	}, "\x00")
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+// FromEnvironment returns a complete legacy GN_* configuration, if present.
+func FromEnvironment() (Config, bool) {
+	postalCode := strings.TrimSpace(os.Getenv("GN_ZIPCODE"))
+	headendID := strings.TrimSpace(os.Getenv("GN_HEADEND"))
+	lineupID := strings.TrimSpace(os.Getenv("GN_LINEUP"))
+	if postalCode == "" || headendID == "" || lineupID == "" {
+		return Config{}, false
+	}
+
+	country := strings.TrimSpace(os.Getenv("GN_COUNTRY"))
+	if country == "" {
+		country = "USA"
+	}
+	language := strings.TrimSpace(os.Getenv("GN_LANGUAGE"))
+	if language == "" {
+		language = "en-us"
+	}
+	device := strings.TrimSpace(os.Getenv("GN_DEVICE"))
+	if device == "" {
+		device = "-"
+	}
+
+	config := Config{
+		Version: CurrentVersion,
+		Gracenote: GracenoteConfig{
+			Country:      country,
+			PostalCode:   postalCode,
+			Language:     language,
+			Device:       device,
+			LineupID:     lineupID,
+			ProviderName: "Environment configuration",
+			HeadendID:    headendID,
+		},
+	}.normalized()
+	if err := config.Validate(); err != nil {
+		return Config{}, false
+	}
+	return config, true
+}
+
+type Store struct {
+	mu         sync.RWMutex
+	path       string
+	config     Config
+	configured bool
+	source     string
+}
+
+// LoadStore loads saved setup first, then falls back to a complete legacy
+// environment configuration. A non-nil store is returned even when a saved
+// file is invalid so server mode can still expose /setup for recovery.
+func LoadStore(path string) (*Store, error) {
+	store := &Store{path: path}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return store, fmt.Errorf("reading configuration: %w", err)
+		}
+		if config, ok := FromEnvironment(); ok {
+			store.config = config
+			store.configured = true
+			store.source = "environment"
+		}
+		return store, nil
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return store, fmt.Errorf("decoding configuration: %w", err)
+	}
+	config = config.normalized()
+	if err := config.Validate(); err != nil {
+		return store, fmt.Errorf("validating configuration: %w", err)
+	}
+	store.config = config
+	store.configured = true
+	store.source = "file"
+	return store, nil
+}
+
+func (s *Store) Get() (Config, bool, string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config, s.configured, s.source
+}
+
+// WhileCurrent runs fn while holding a read lock only when fingerprint still
+// identifies the active source. Save waits for fn to finish, which prevents an
+// old scrape from publishing files after a provider change.
+func (s *Store) WhileCurrent(fingerprint string, fn func() error) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.configured || s.config.Fingerprint() != fingerprint {
+		return false, nil
+	}
+	return true, fn()
+}
+
+func (s *Store) Save(config Config) error {
+	if config.Version == 0 {
+		config.Version = CurrentVersion
+	}
+	config = config.normalized()
+	if err := config.Validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding configuration: %w", err)
+	}
+	data = append(data, '\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating configuration directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, ".gracenote-config-*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temporary configuration: %w", err)
+	}
+	tmpName := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("securing temporary configuration: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("writing configuration: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("syncing configuration: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("closing configuration: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("replacing configuration: %w", err)
+	}
+	removeTemp = false
+	if err := os.Chmod(s.path, 0600); err != nil {
+		return fmt.Errorf("securing configuration: %w", err)
+	}
+
+	s.config = config
+	s.configured = true
+	s.source = "file"
+	return nil
+}

--- a/appconfig/config_test.go
+++ b/appconfig/config_test.go
@@ -1,0 +1,123 @@
+package appconfig
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func testConfig() Config {
+	return Config{
+		Version: CurrentVersion,
+		Gracenote: GracenoteConfig{
+			Country:      "USA",
+			PostalCode:   "11743",
+			Language:     "en-us",
+			ProviderType: "CABLE",
+			Device:       "X",
+			LineupID:     "USA-NY67791-DEFAULT",
+			ProviderName: "Verizon Fios - Digital",
+			Location:     "Huntington",
+			HeadendID:    "NY67791",
+		},
+	}
+}
+
+func TestStoreSaveAndReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	store, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore() error = %v", err)
+	}
+	if _, configured, _ := store.Get(); configured {
+		t.Fatal("new store is configured")
+	}
+
+	want := testConfig()
+	if err := store.Save(want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0600 {
+			t.Fatalf("config permissions = %o, want 600", got)
+		}
+	}
+
+	reloaded, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore(reload) error = %v", err)
+	}
+	got, configured, source := reloaded.Get()
+	if !configured || source != "file" {
+		t.Fatalf("configured = %v, source = %q", configured, source)
+	}
+	if got.Fingerprint() != want.Fingerprint() {
+		t.Fatalf("fingerprint = %q, want %q", got.Fingerprint(), want.Fingerprint())
+	}
+}
+
+func TestStoreBootstrapsCompleteEnvironment(t *testing.T) {
+	t.Setenv("GN_COUNTRY", "USA")
+	t.Setenv("GN_ZIPCODE", "90210")
+	t.Setenv("GN_LANGUAGE", "en-us")
+	t.Setenv("GN_DEVICE", "X")
+	t.Setenv("GN_LINEUP", "USA-DITV803-DEFAULT")
+	t.Setenv("GN_HEADEND", "DITV803")
+
+	store, err := LoadStore(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatalf("LoadStore() error = %v", err)
+	}
+	config, configured, source := store.Get()
+	if !configured || source != "environment" {
+		t.Fatalf("configured = %v, source = %q", configured, source)
+	}
+	if config.Gracenote.PostalCode != "90210" || config.Gracenote.LineupID != "USA-DITV803-DEFAULT" {
+		t.Fatalf("unexpected config: %+v", config)
+	}
+}
+
+func TestSavedConfigurationWinsOverEnvironment(t *testing.T) {
+	t.Setenv("GN_ZIPCODE", "90210")
+	t.Setenv("GN_LINEUP", "USA-DITV803-DEFAULT")
+	t.Setenv("GN_HEADEND", "DITV803")
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	store, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore() error = %v", err)
+	}
+	if err := store.Save(testConfig()); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	reloaded, err := LoadStore(path)
+	if err != nil {
+		t.Fatalf("LoadStore(reload) error = %v", err)
+	}
+	config, _, source := reloaded.Get()
+	if source != "file" || config.Gracenote.PostalCode != "11743" {
+		t.Fatalf("saved configuration did not win: source=%q config=%+v", source, config)
+	}
+}
+
+func TestConfigValidationRejectsIncompleteProvider(t *testing.T) {
+	config := testConfig()
+	config.Gracenote.HeadendID = ""
+	if err := config.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want validation error")
+	}
+}
+
+func TestConfigValidationRejectsFutureVersion(t *testing.T) {
+	config := testConfig()
+	config.Version = CurrentVersion + 1
+	if err := config.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want version error")
+	}
+}

--- a/index.html
+++ b/index.html
@@ -71,7 +71,22 @@ body::after {
   text-transform: uppercase;
 }
 
-.topbar-right { text-align: right; }
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  text-align: right;
+}
+
+.topbar-setup {
+  color: var(--dim);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.topbar-setup:hover { color: var(--cyan); }
 
 .topbar-clock {
   font-size: 18px;
@@ -669,8 +684,11 @@ body.livetv-on .detail-bar { display: none !important; }
 <div class="topbar">
   <span class="topbar-title">The Grid</span>
   <div class="topbar-right">
-    <div class="topbar-clock" id="clock">--:--:--</div>
-    <div class="topbar-date" id="date">---</div>
+    <a class="topbar-setup" href="/setup">Lineup setup</a>
+    <div>
+      <div class="topbar-clock" id="clock">--:--:--</div>
+      <div class="topbar-date" id="date">---</div>
+    </div>
   </div>
 </div>
 
@@ -776,7 +794,11 @@ body.livetv-on .detail-bar { display: none !important; }
   function fetchGuide() {
     fetch('/api/guide.json')
       .then(function(r) {
-        if (!r.ok) throw new Error('HTTP ' + r.status);
+        if (!r.ok) {
+          var error = new Error(r.status === 503 ? 'BUILDING GUIDE \u2014 CHECKING AGAIN SOON' : 'HTTP ' + r.status);
+          error.building = r.status === 503;
+          throw error;
+        }
         return r.json();
       })
       .then(function(data) {
@@ -789,10 +811,11 @@ body.livetv-on .detail-bar { display: none !important; }
       })
       .catch(function(err) {
         if (!guideData) {
-          statusEl.textContent  = 'SIGNAL LOST \u2014 ' + err.message;
-          statusEl.className    = 'status-msg error';
+          statusEl.textContent  = err.building ? err.message : 'SIGNAL LOST \u2014 ' + err.message;
+          statusEl.className    = err.building ? 'status-msg' : 'status-msg error';
           statusEl.style.display = '';
         }
+        if (err.building) setTimeout(fetchGuide, 30000);
       });
   }
   fetchGuide();

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"html"
@@ -24,6 +25,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/daniel-widrick/GraceNoteScraper/appconfig"
 	"github.com/daniel-widrick/GraceNoteScraper/guide"
 	"github.com/daniel-widrick/GraceNoteScraper/tmdb"
 	"github.com/daniel-widrick/GraceNoteScraper/tvlogo"
@@ -180,10 +182,14 @@ func xmltvTimeToISO(xmltvTime string) string {
 
 // ---------- Scraping ----------
 
+var errScrapeSourceChanged = errors.New("active lineup changed during scrape")
+
+type guidePersister func(*guide.TVGuide) (bool, error)
+
 // runScrape performs the full scrape cycle and returns the populated TVGuide.
 // It also writes xmlguide.xmltv atomically.
-func runScrape(tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country, baseURL string, channelFilter map[string]bool) (*guide.TVGuide, error) {
-	client := web.NewClient()
+func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, channelFilter map[string]bool, sourceFingerprint string, sourceCurrent func() bool, persister guidePersister) (*guide.TVGuide, error) {
+	client := web.NewClient(pref)
 
 	now := time.Now().UTC()
 	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
@@ -196,6 +202,9 @@ func runScrape(tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country
 	totalSlots := int(endTime.Sub(midnight) / (6 * time.Hour))
 	slot := 0
 	for t := midnight; t.Before(endTime); t = t.Add(6 * time.Hour) {
+		if sourceCurrent != nil && !sourceCurrent() {
+			return nil, errScrapeSourceChanged
+		}
 		slot++
 		ts := t.Unix()
 		log.Printf("Fetching grid %d/%d for time=%d (%s)", slot, totalSlots, ts, t.Format(time.RFC3339))
@@ -217,7 +226,7 @@ func runScrape(tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country
 					continue
 				}
 				eventMap[dedupKey] = true
-				programs = append(programs, guide.ConvertEvent(ev, ch.ChannelID, lang, country))
+				programs = append(programs, guide.ConvertEvent(ev, ch.ChannelID, pref.Language, pref.Country))
 			}
 		}
 
@@ -233,6 +242,10 @@ func runScrape(tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country
 		channels = append(channels, ch)
 	}
 
+	logoClient := tvlogo.NewClient(pref.Country, "tvlogo_cache.json")
+	if logoClient != nil {
+		defer logoClient.Close()
+	}
 	enrichChannelIcons(logoClient, channels)
 	enrichProgramThumbnails(tmdbClient, programs)
 	fixDeadImageURLs(programs)
@@ -269,37 +282,57 @@ func runScrape(tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country
 		log.Printf("Channel filter: %d → %d channels (Jellyfin has %d)", before, len(tvGuide.Channels), len(channelFilter))
 	}
 
+	if persister != nil {
+		persisted, err := persister(tvGuide)
+		if err != nil {
+			return nil, err
+		}
+		if !persisted {
+			return nil, errScrapeSourceChanged
+		}
+	} else if err := persistGuideFiles(tvGuide, sourceFingerprint); err != nil {
+		return nil, err
+	}
+	return tvGuide, nil
+}
+
+func persistGuideFiles(tvGuide *guide.TVGuide, sourceFingerprint string) error {
 	log.Printf("Rendering XMLTV: %d channels, %d programs", len(tvGuide.Channels), len(tvGuide.Programs))
 
 	// Parse embedded template
 	tmpl, err := template.ParseFS(guideTmplFS, "guide.tmpl")
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse template: %w", err)
+		return fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	// Atomic write: write to temp file, then rename
 	tmpFile, err := os.CreateTemp(".", "xmlguide-*.tmp")
 	if err != nil {
-		return nil, fmt.Errorf("failed to create temp file: %w", err)
+		return fmt.Errorf("failed to create temp file: %w", err)
 	}
 	tmpName := tmpFile.Name()
 
 	if err := tmpl.Execute(tmpFile, tvGuide); err != nil {
 		tmpFile.Close()
 		os.Remove(tmpName)
-		return nil, fmt.Errorf("failed to execute template: %w", err)
+		return fmt.Errorf("failed to execute template: %w", err)
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("failed to close temporary guide: %w", err)
+	}
 
 	if err := os.Rename(tmpName, "xmlguide.xmltv"); err != nil {
 		os.Remove(tmpName)
-		return nil, fmt.Errorf("failed to rename output file: %w", err)
+		return fmt.Errorf("failed to rename output file: %w", err)
 	}
-	os.Chmod("xmlguide.xmltv", 0644)
+	if err := os.Chmod("xmlguide.xmltv", 0644); err != nil {
+		return fmt.Errorf("failed to set guide permissions: %w", err)
+	}
 
 	log.Printf("Wrote guide to xmlguide.xmltv")
-	saveGuideCache(tvGuide)
-	return tvGuide, nil
+	saveGuideCache(tvGuide, sourceFingerprint)
+	return nil
 }
 
 // ---------- Guide cache ----------
@@ -307,13 +340,14 @@ func runScrape(tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country
 const guideCachePath = "guide_cache.json"
 
 type guideCache struct {
-	SavedAt time.Time     `json:"saved_at"`
-	Guide   guide.TVGuide `json:"guide"`
+	SavedAt           time.Time     `json:"saved_at"`
+	SourceFingerprint string        `json:"source_fingerprint"`
+	Guide             guide.TVGuide `json:"guide"`
 }
 
 // saveGuideCache persists the TVGuide to a JSON file.
-func saveGuideCache(g *guide.TVGuide) {
-	data, err := json.Marshal(guideCache{SavedAt: time.Now(), Guide: *g})
+func saveGuideCache(g *guide.TVGuide, sourceFingerprint string) {
+	data, err := json.Marshal(guideCache{SavedAt: time.Now(), SourceFingerprint: sourceFingerprint, Guide: *g})
 	if err != nil {
 		log.Printf("guide cache: failed to marshal: %v", err)
 		return
@@ -327,7 +361,7 @@ func saveGuideCache(g *guide.TVGuide) {
 
 // loadGuideCache loads the TVGuide from the JSON cache if it's younger than maxAge.
 // Returns the guide, its age, and whether it was loaded.
-func loadGuideCache(maxAge time.Duration) (*guide.TVGuide, time.Duration, bool) {
+func loadGuideCache(maxAge time.Duration, sourceFingerprint string) (*guide.TVGuide, time.Duration, bool) {
 	data, err := os.ReadFile(guideCachePath)
 	if err != nil {
 		return nil, 0, false
@@ -337,11 +371,23 @@ func loadGuideCache(maxAge time.Duration) (*guide.TVGuide, time.Duration, bool) 
 		log.Printf("guide cache: corrupt, ignoring: %v", err)
 		return nil, 0, false
 	}
+	if c.SourceFingerprint != sourceFingerprint {
+		log.Println("guide cache: source changed, ignoring cached guide")
+		return nil, 0, false
+	}
 	age := time.Since(c.SavedAt)
 	if age >= maxAge {
 		return nil, age, false
 	}
 	return &c.Guide, age, true
+}
+
+func invalidateCurrentGuideArtifacts() {
+	for _, path := range []string{"xmlguide.xmltv", guideCachePath} {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.Printf("setup: could not remove stale %s: %v", path, err)
+		}
+	}
 }
 
 // ---------- File rotation ----------
@@ -378,10 +424,9 @@ func rotateFiles() {
 
 // ---------- Background scraper ----------
 
-// startScraper runs the scrape cycle on a 24-hour ticker.
-// If initialDelay > 0, the first scrape fires after that delay instead of 24h
-// (used when we skipped the startup scrape because the file was still fresh).
-func startScraper(ctx context.Context, state *GuideState, tmdbClient *tmdb.Client, logoClient *tvlogo.Client, lang, country, baseURL string, initialDelay time.Duration, jellyfinURL, jellyfinAPIKey string, filterEnabled bool) {
+// startScraper runs the active lineup on a 24-hour timer and accepts immediate
+// requests after setup changes.
+func startScraper(ctx context.Context, state *GuideState, store *appconfig.Store, tmdbClient *tmdb.Client, baseURL string, initialDelay time.Duration, trigger <-chan struct{}, jellyfinURL, jellyfinAPIKey string, filterEnabled bool) {
 	if initialDelay <= 0 {
 		initialDelay = 24 * time.Hour
 	}
@@ -390,58 +435,122 @@ func startScraper(ctx context.Context, state *GuideState, tmdbClient *tmdb.Clien
 	defer timer.Stop()
 
 	for {
+		reason := "scheduled"
 		select {
 		case <-ctx.Done():
 			log.Println("Scraper shutting down")
 			return
 		case <-timer.C:
-			log.Println("Starting scheduled scrape cycle")
+		case <-trigger:
+			reason = "setup-requested"
+		}
 
-			var channelFilter map[string]bool
-			if filterEnabled {
-				cf, err := fetchJellyfinChannelNumbers(jellyfinURL, jellyfinAPIKey)
-				if err != nil {
-					log.Printf("Warning: could not fetch Jellyfin channels for filter, proceeding unfiltered: %v", err)
-				} else {
-					channelFilter = cf
-				}
-			}
+		config, configured, _ := store.Get()
+		if !configured {
+			log.Println("Scraper is waiting for a provider selection at /setup")
+			resetScrapeTimer(timer, 24*time.Hour)
+			continue
+		}
 
-			g, err := runScrape(tmdbClient, logoClient, lang, country, baseURL, channelFilter)
+		log.Printf("Starting %s scrape for %s", reason, config.Gracenote.ProviderName)
+		var channelFilter map[string]bool
+		if filterEnabled {
+			cf, err := fetchJellyfinChannelNumbers(jellyfinURL, jellyfinAPIKey)
 			if err != nil {
-				log.Printf("Scheduled scrape failed: %v", err)
+				log.Printf("Warning: could not fetch Jellyfin channels for filter, proceeding unfiltered: %v", err)
 			} else {
+				channelFilter = cf
+			}
+		}
+
+		fingerprint := config.Fingerprint()
+		persister := func(g *guide.TVGuide) (bool, error) {
+			return store.WhileCurrent(fingerprint, func() error {
+				if err := persistGuideFiles(g, fingerprint); err != nil {
+					return err
+				}
 				state.Update(g)
 				rotateFiles()
-				log.Println("Scheduled scrape complete")
-			}
-			// All subsequent runs at 24h intervals
-			timer.Reset(24 * time.Hour)
+				return nil
+			})
 		}
+		sourceCurrent := func() bool {
+			current, ok, _ := store.Get()
+			return ok && current.Fingerprint() == fingerprint
+		}
+		_, err := runScrape(config.Preferences(), tmdbClient, baseURL, channelFilter, fingerprint, sourceCurrent, persister)
+		nextDelay := 24 * time.Hour
+		if errors.Is(err, errScrapeSourceChanged) {
+			log.Println("Discarded scrape because the active lineup changed")
+		} else if err != nil {
+			log.Printf("Scrape failed: %v", err)
+			nextDelay = 15 * time.Minute
+		} else {
+			log.Println("Scrape complete")
+		}
+		resetScrapeTimer(timer, nextDelay)
+	}
+}
+
+func resetScrapeTimer(timer *time.Timer, delay time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(delay)
+}
+
+func queueScrape(trigger chan<- struct{}) {
+	select {
+	case trigger <- struct{}{}:
+	default:
 	}
 }
 
 // ---------- HTTP handlers ----------
 
-func handleIndex(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
-		http.NotFound(w, r)
-		return
+func handleIndex(store *appconfig.Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if _, configured, _ := store.Get(); !configured {
+			http.Redirect(w, r, "/setup", http.StatusSeeOther)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if r.Method == http.MethodGet {
+			_, _ = w.Write(indexHTML)
+		}
 	}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write(indexHTML)
 }
 
-func handleXMLTV(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/xml")
-	http.ServeFile(w, r, "xmlguide.xmltv")
+func handleXMLTV(state *GuideState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if state.Get() == nil {
+			w.Header().Set("Retry-After", "30")
+			http.Error(w, "Guide is being generated", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		http.ServeFile(w, r, "xmlguide.xmltv")
+	}
 }
 
 func handleGuideJSON(state *GuideState) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		g := state.Get()
 		if g == nil {
-			http.Error(w, "Guide not available yet", http.StatusServiceUnavailable)
+			w.Header().Set("Retry-After", "30")
+			http.Error(w, "Guide is being generated", http.StatusServiceUnavailable)
 			return
 		}
 
@@ -823,10 +932,13 @@ func main() {
 		log.Println("No .env file found, using environment variables")
 	}
 
-	lang := util.GetEnv("GN_LANGUAGE", "en")
-	country := util.GetEnv("GN_COUNTRY", "USA")
 	port := util.GetEnv("PORT", "8080")
 	baseURL := util.GetEnv("BASE_URL", "")
+	configPath := util.GetEnv("CONFIG_PATH", "config.json")
+	configStore, configErr := appconfig.LoadStore(configPath)
+	if configErr != nil {
+		log.Printf("Configuration could not be loaded; /setup will remain available: %v", configErr)
+	}
 
 	jellyfinURL := strings.TrimRight(util.GetEnv("JELLYFIN_URL", ""), "/")
 	jellyfinAPIKey := util.GetEnv("JELLYFIN_API_KEY", "")
@@ -858,55 +970,48 @@ func main() {
 	}
 	defer tmdbClient.Close()
 
-	logoClient := tvlogo.NewClient(country, "tvlogo_cache.json")
-	if logoClient != nil {
-		log.Println("TV logo enrichment enabled")
-	} else {
-		log.Printf("TV logo enrichment not available for country %s", country)
-	}
-	defer logoClient.Close()
-
 	// --guide-only: always scrape, write output, exit
 	if *guideOnly {
+		config, configured, _ := configStore.Get()
+		if !configured {
+			log.Fatal("No provider is configured. Run server mode and open /setup, or provide complete GN_* environment settings.")
+		}
 		log.Println("Starting scrape (guide-only mode)...")
-		if _, err := runScrape(tmdbClient, logoClient, lang, country, baseURL, channelFilter); err != nil {
+		if _, err := runScrape(config.Preferences(), tmdbClient, baseURL, channelFilter, config.Fingerprint(), nil, nil); err != nil {
 			log.Fatalf("Scrape failed: %v", err)
 		}
 		log.Println("--guide-only: done")
 		return
 	}
 
-	// Server mode: try loading cached guide data to skip a slow scrape.
-	// Always re-scrape if the XMLTV file or guide cache is missing.
+	// Server mode starts immediately so first-run setup remains available while
+	// the initial guide is generated in the background.
 	var g *guide.TVGuide
-	var nextScrapeIn time.Duration
-	_, xmltvMissing := os.Stat("xmlguide.xmltv")
-	cached, age, cacheOK := loadGuideCache(4 * time.Hour)
-	if cacheOK && xmltvMissing == nil {
-		log.Printf("Loaded guide from cache (%s old), skipping scrape", age.Round(time.Second))
-		g = cached
-		if channelFilter != nil {
-			before := len(g.Channels)
-			g = filterGuideChannels(g, channelFilter)
-			log.Printf("Channel filter: %d → %d channels (cached guide)", before, len(g.Channels))
-		}
-		// Schedule next scrape for when the cache turns 24h old
-		nextScrapeIn = 24*time.Hour - age
-		if nextScrapeIn < time.Hour {
-			nextScrapeIn = time.Hour
+	nextScrapeIn := 24 * time.Hour
+	config, configured, source := configStore.Get()
+	if configured {
+		log.Printf("Active lineup: %s (%s)", config.Gracenote.ProviderName, source)
+		_, xmltvErr := os.Stat("xmlguide.xmltv")
+		cached, age, cacheOK := loadGuideCache(4*time.Hour, config.Fingerprint())
+		if cacheOK && xmltvErr == nil {
+			log.Printf("Loaded guide from cache (%s old), skipping initial scrape", age.Round(time.Second))
+			g = cached
+			if channelFilter != nil {
+				before := len(g.Channels)
+				g = filterGuideChannels(g, channelFilter)
+				log.Printf("Channel filter: %d → %d channels (cached guide)", before, len(g.Channels))
+			}
+			nextScrapeIn = 24*time.Hour - age
+			if nextScrapeIn < time.Hour {
+				nextScrapeIn = time.Hour
+			}
+		} else {
+			invalidateCurrentGuideArtifacts()
+			nextScrapeIn = 100 * time.Millisecond
+			log.Println("A fresh guide will be generated in the background")
 		}
 	} else {
-		if xmltvMissing != nil {
-			log.Println("xmlguide.xmltv missing, scrape required")
-		}
-		log.Println("Starting initial scrape...")
-		var err error
-		g, err = runScrape(tmdbClient, logoClient, lang, country, baseURL, channelFilter)
-		if err != nil {
-			log.Fatalf("Initial scrape failed: %v", err)
-		}
-		rotateFiles()
-		nextScrapeIn = 24 * time.Hour
+		log.Println("No provider configured; open /setup to choose a lineup")
 	}
 
 	state := &GuideState{}
@@ -916,14 +1021,35 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	scrapeTrigger := make(chan struct{}, 1)
+	setupHandlers := &setupServer{
+		store:     configStore,
+		providers: web.NewProviderClient(),
+		onProviderSaved: func(changed bool) {
+			if changed {
+				state.Update(nil)
+				invalidateCurrentGuideArtifacts()
+			}
+			queueScrape(scrapeTrigger)
+		},
+	}
+
 	// Start background scraper
-	log.Printf("Next scrape in %s", nextScrapeIn.Round(time.Minute))
-	go startScraper(ctx, state, tmdbClient, logoClient, lang, country, baseURL, nextScrapeIn, jellyfinURL, jellyfinAPIKey, channelFilterEnabled)
+	if configured && nextScrapeIn < time.Second {
+		log.Println("Initial scrape queued")
+	} else {
+		log.Printf("Next scrape in %s", nextScrapeIn.Round(time.Minute))
+	}
+	go startScraper(ctx, state, configStore, tmdbClient, baseURL, nextScrapeIn, scrapeTrigger, jellyfinURL, jellyfinAPIKey, channelFilterEnabled)
 
 	// HTTP server
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", handleIndex)
-	mux.HandleFunc("/xmlguide.xmltv", handleXMLTV)
+	mux.HandleFunc("/", handleIndex(configStore))
+	mux.HandleFunc("/setup", setupHandlers.handlePage)
+	mux.HandleFunc("/api/setup/config", setupHandlers.handleConfig)
+	mux.HandleFunc("/api/setup/providers", setupHandlers.handleProviders)
+	mux.HandleFunc("/api/setup/provider", setupHandlers.handleProvider)
+	mux.HandleFunc("/xmlguide.xmltv", handleXMLTV(state))
 	mux.HandleFunc("/api/guide.json", handleGuideJSON(state))
 	mux.HandleFunc("/img", handleImage)
 	mux.HandleFunc("/api/livetv/config", handleLiveTVConfig(jellyfinURL, jellyfinAPIKey))

--- a/main.go
+++ b/main.go
@@ -186,9 +186,27 @@ var errScrapeSourceChanged = errors.New("active lineup changed during scrape")
 
 type guidePersister func(*guide.TVGuide) (bool, error)
 
+type scrapeProgressUpdate struct {
+	Stage     string
+	Message   string
+	Completed int
+	Total     int
+	Channels  int
+	Programs  int
+}
+
+type scrapeProgressReporter func(scrapeProgressUpdate)
+
 // runScrape performs the full scrape cycle and returns the populated TVGuide.
 // It also writes xmlguide.xmltv atomically.
-func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, channelFilter map[string]bool, sourceFingerprint string, sourceCurrent func() bool, persister guidePersister) (*guide.TVGuide, error) {
+func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, channelFilter map[string]bool, sourceFingerprint string, sourceCurrent func() bool, persister guidePersister, reporters ...scrapeProgressReporter) (*guide.TVGuide, error) {
+	report := func(update scrapeProgressUpdate) {
+		for _, reporter := range reporters {
+			if reporter != nil {
+				reporter(update)
+			}
+		}
+	}
 	client := web.NewClient(pref)
 
 	now := time.Now().UTC()
@@ -207,6 +225,7 @@ func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, ch
 		}
 		slot++
 		ts := t.Unix()
+		report(scrapeProgressUpdate{Stage: "gracenote", Message: fmt.Sprintf("Downloading guide data (%d of %d)", slot, totalSlots), Completed: slot - 1, Total: totalSlots, Channels: len(channelMap), Programs: len(programs)})
 		log.Printf("Fetching grid %d/%d for time=%d (%s)", slot, totalSlots, ts, t.Format(time.RFC3339))
 
 		grid, err := client.GetDataByTime(ts)
@@ -231,6 +250,7 @@ func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, ch
 		}
 
 		log.Printf("Channels so far: %d, Events so far: %d", len(channelMap), len(programs))
+		report(scrapeProgressUpdate{Stage: "gracenote", Message: fmt.Sprintf("Downloaded guide data (%d of %d)", slot, totalSlots), Completed: slot, Total: totalSlots, Channels: len(channelMap), Programs: len(programs)})
 
 		if t.Add(6 * time.Hour).Before(endTime) {
 			time.Sleep(5 * time.Second)
@@ -246,8 +266,11 @@ func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, ch
 	if logoClient != nil {
 		defer logoClient.Close()
 	}
+	report(scrapeProgressUpdate{Stage: "logos", Message: "Matching channel logos", Channels: len(channels), Programs: len(programs)})
 	enrichChannelIcons(logoClient, channels)
-	enrichProgramThumbnails(tmdbClient, programs)
+	enrichProgramThumbnails(tmdbClient, programs, func(completed, total int) {
+		report(scrapeProgressUpdate{Stage: "tmdb", Message: fmt.Sprintf("Enriching program titles (%d of %d)", completed, total), Completed: completed, Total: total, Channels: len(channels), Programs: len(programs)})
+	})
 	fixDeadImageURLs(programs)
 
 	// Rewrite image URLs to go through the local proxy
@@ -283,6 +306,7 @@ func runScrape(pref web.Preferences, tmdbClient *tmdb.Client, baseURL string, ch
 	}
 
 	if persister != nil {
+		report(scrapeProgressUpdate{Stage: "saving", Message: "Rendering and saving the guide", Channels: len(tvGuide.Channels), Programs: len(tvGuide.Programs)})
 		persisted, err := persister(tvGuide)
 		if err != nil {
 			return nil, err
@@ -426,7 +450,7 @@ func rotateFiles() {
 
 // startScraper runs the active lineup on a 24-hour timer and accepts immediate
 // requests after setup changes.
-func startScraper(ctx context.Context, state *GuideState, store *appconfig.Store, tmdbClient *tmdb.Client, baseURL string, initialDelay time.Duration, trigger <-chan struct{}, jellyfinURL, jellyfinAPIKey string, filterEnabled bool) {
+func startScraper(ctx context.Context, state *GuideState, store *appconfig.Store, tmdbClient *tmdb.Client, baseURL string, initialDelay time.Duration, trigger <-chan struct{}, jellyfinURL, jellyfinAPIKey string, filterEnabled bool, status *scrapeStatus) {
 	if initialDelay <= 0 {
 		initialDelay = 24 * time.Hour
 	}
@@ -453,6 +477,9 @@ func startScraper(ctx context.Context, state *GuideState, store *appconfig.Store
 		}
 
 		log.Printf("Starting %s scrape for %s", reason, config.Gracenote.ProviderName)
+		if status != nil {
+			status.start("Starting guide download")
+		}
 		var channelFilter map[string]bool
 		if filterEnabled {
 			cf, err := fetchJellyfinChannelNumbers(jellyfinURL, jellyfinAPIKey)
@@ -478,15 +505,30 @@ func startScraper(ctx context.Context, state *GuideState, store *appconfig.Store
 			current, ok, _ := store.Get()
 			return ok && current.Fingerprint() == fingerprint
 		}
-		_, err := runScrape(config.Preferences(), tmdbClient, baseURL, channelFilter, fingerprint, sourceCurrent, persister)
+		var reporter scrapeProgressReporter
+		if status != nil {
+			reporter = func(update scrapeProgressUpdate) {
+				status.update(update.Stage, update.Message, update.Completed, update.Total, update.Channels, update.Programs)
+			}
+		}
+		builtGuide, err := runScrape(config.Preferences(), tmdbClient, baseURL, channelFilter, fingerprint, sourceCurrent, persister, reporter)
 		nextDelay := 24 * time.Hour
 		if errors.Is(err, errScrapeSourceChanged) {
 			log.Println("Discarded scrape because the active lineup changed")
+			if status != nil {
+				status.queue("Waiting to build the newly selected lineup")
+			}
 		} else if err != nil {
 			log.Printf("Scrape failed: %v", err)
+			if status != nil {
+				status.fail("Guide build failed: " + err.Error())
+			}
 			nextDelay = 15 * time.Minute
 		} else {
 			log.Println("Scrape complete")
+			if status != nil {
+				status.ready(len(builtGuide.Channels), len(builtGuide.Programs))
+			}
 		}
 		resetScrapeTimer(timer, nextDelay)
 	}
@@ -1016,6 +1058,12 @@ func main() {
 
 	state := &GuideState{}
 	state.Update(g)
+	guideChannels, guidePrograms := 0, 0
+	if g != nil {
+		guideChannels = len(g.Channels)
+		guidePrograms = len(g.Programs)
+	}
+	guideStatus := newScrapeStatus(g != nil, guideChannels, guidePrograms)
 
 	// Signal context for graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -1023,13 +1071,16 @@ func main() {
 
 	scrapeTrigger := make(chan struct{}, 1)
 	setupHandlers := &setupServer{
-		store:     configStore,
-		providers: web.NewProviderClient(),
+		store:          configStore,
+		providers:      web.NewProviderClient(),
+		channelCounter: webProviderChannelCounter{},
+		scrapeStatus:   guideStatus,
 		onProviderSaved: func(changed bool) {
 			if changed {
 				state.Update(nil)
 				invalidateCurrentGuideArtifacts()
 			}
+			guideStatus.queue("Guide build queued")
 			queueScrape(scrapeTrigger)
 		},
 	}
@@ -1037,10 +1088,11 @@ func main() {
 	// Start background scraper
 	if configured && nextScrapeIn < time.Second {
 		log.Println("Initial scrape queued")
+		guideStatus.queue("Initial guide build queued")
 	} else {
 		log.Printf("Next scrape in %s", nextScrapeIn.Round(time.Minute))
 	}
-	go startScraper(ctx, state, configStore, tmdbClient, baseURL, nextScrapeIn, scrapeTrigger, jellyfinURL, jellyfinAPIKey, channelFilterEnabled)
+	go startScraper(ctx, state, configStore, tmdbClient, baseURL, nextScrapeIn, scrapeTrigger, jellyfinURL, jellyfinAPIKey, channelFilterEnabled, guideStatus)
 
 	// HTTP server
 	mux := http.NewServeMux()
@@ -1049,6 +1101,7 @@ func main() {
 	mux.HandleFunc("/api/setup/config", setupHandlers.handleConfig)
 	mux.HandleFunc("/api/setup/providers", setupHandlers.handleProviders)
 	mux.HandleFunc("/api/setup/provider", setupHandlers.handleProvider)
+	mux.HandleFunc("/api/setup/status", setupHandlers.handleScrapeStatus)
 	mux.HandleFunc("/xmlguide.xmltv", handleXMLTV(state))
 	mux.HandleFunc("/api/guide.json", handleGuideJSON(state))
 	mux.HandleFunc("/img", handleImage)
@@ -1097,7 +1150,7 @@ func xmlEscape(s string) string {
 
 // replaces broken Gracenote thumbnail URLs with TMDB
 // poster images, star ratings, dates, and descriptions.
-func enrichProgramThumbnails(client *tmdb.Client, programs []guide.Program) {
+func enrichProgramThumbnails(client *tmdb.Client, programs []guide.Program, progress ...func(completed, total int)) {
 	if client == nil {
 		return
 	}
@@ -1127,11 +1180,21 @@ func enrichProgramThumbnails(client *tmdb.Client, programs []guide.Program) {
 	}
 
 	log.Printf("TMDB: looking up %d unique titles", len(unique))
+	for _, update := range progress {
+		if update != nil {
+			update(0, len(unique))
+		}
+	}
 
 	// Phase 2: lookup each unique title
 	results := make(map[titleKey]tmdb.CacheEntry)
-	for _, k := range unique {
+	for index, k := range unique {
 		results[k] = client.Lookup(k.title, k.isMovie)
+		for _, update := range progress {
+			if update != nil {
+				update(index+1, len(unique))
+			}
+		}
 	}
 
 	// Phase 3: apply results back to programs

--- a/scrape_status.go
+++ b/scrape_status.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+type scrapeStatusSnapshot struct {
+	Running     bool      `json:"running"`
+	Stage       string    `json:"stage"`
+	Message     string    `json:"message"`
+	Completed   int       `json:"completed,omitempty"`
+	Total       int       `json:"total,omitempty"`
+	Channels    int       `json:"channels,omitempty"`
+	Programs    int       `json:"programs,omitempty"`
+	StartedAt   time.Time `json:"startedAt,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	CompletedAt time.Time `json:"completedAt,omitempty"`
+}
+
+type scrapeStatus struct {
+	mu       sync.RWMutex
+	snapshot scrapeStatusSnapshot
+}
+
+func newScrapeStatus(guideReady bool, channels, programs int) *scrapeStatus {
+	status := &scrapeStatus{}
+	now := time.Now().UTC()
+	if guideReady {
+		status.snapshot = scrapeStatusSnapshot{
+			Stage: "ready", Message: "Guide ready", Channels: channels, Programs: programs,
+			UpdatedAt: now, CompletedAt: now,
+		}
+	} else {
+		status.snapshot = scrapeStatusSnapshot{Stage: "idle", Message: "Waiting for a guide build", UpdatedAt: now}
+	}
+	return status
+}
+
+func (s *scrapeStatus) queue(message string) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	s.snapshot = scrapeStatusSnapshot{Running: true, Stage: "queued", Message: message, UpdatedAt: now}
+	s.mu.Unlock()
+}
+
+func (s *scrapeStatus) start(message string) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	s.snapshot = scrapeStatusSnapshot{Running: true, Stage: "starting", Message: message, StartedAt: now, UpdatedAt: now}
+	s.mu.Unlock()
+}
+
+func (s *scrapeStatus) update(stage, message string, completed, total, channels, programs int) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	startedAt := s.snapshot.StartedAt
+	if startedAt.IsZero() {
+		startedAt = now
+	}
+	s.snapshot = scrapeStatusSnapshot{
+		Running: true, Stage: stage, Message: message, Completed: completed, Total: total,
+		Channels: channels, Programs: programs, StartedAt: startedAt, UpdatedAt: now,
+	}
+	s.mu.Unlock()
+}
+
+func (s *scrapeStatus) ready(channels, programs int) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	startedAt := s.snapshot.StartedAt
+	s.snapshot = scrapeStatusSnapshot{
+		Stage: "ready", Message: "Guide ready", Channels: channels, Programs: programs,
+		StartedAt: startedAt, UpdatedAt: now, CompletedAt: now,
+	}
+	s.mu.Unlock()
+}
+
+func (s *scrapeStatus) fail(message string) {
+	now := time.Now().UTC()
+	s.mu.Lock()
+	startedAt := s.snapshot.StartedAt
+	s.snapshot = scrapeStatusSnapshot{
+		Stage: "error", Message: message, StartedAt: startedAt, UpdatedAt: now, CompletedAt: now,
+	}
+	s.mu.Unlock()
+}
+
+func (s *scrapeStatus) snapshotValue() scrapeStatusSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.snapshot
+}

--- a/setup.go
+++ b/setup.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"mime"
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/daniel-widrick/GraceNoteScraper/appconfig"
 	"github.com/daniel-widrick/GraceNoteScraper/web"
@@ -22,9 +25,29 @@ type providerFinder interface {
 	FindProviders(ctx context.Context, country, postalCode, language string) (*web.ProviderResponse, error)
 }
 
+type providerChannelCounter interface {
+	CountChannels(ctx context.Context, country, postalCode, language string, provider web.Provider) (int, error)
+}
+
+type webProviderChannelCounter struct{}
+
+func (webProviderChannelCounter) CountChannels(ctx context.Context, country, postalCode, language string, provider web.Provider) (int, error) {
+	client := web.NewClient(web.Preferences{
+		Country: country, ZipCode: postalCode, Headend: provider.HeadendID,
+		LineupId: provider.LineupID, Device: provider.Device, Language: language,
+	})
+	grid, err := client.GetDataByTimeContext(ctx, time.Now().UTC().Truncate(6*time.Hour).Unix())
+	if err != nil {
+		return 0, err
+	}
+	return len(grid.Channels), nil
+}
+
 type setupServer struct {
 	store           *appconfig.Store
 	providers       providerFinder
+	channelCounter  providerChannelCounter
+	scrapeStatus    *scrapeStatus
 	onProviderSaved func(changed bool)
 }
 
@@ -102,6 +125,7 @@ func (s *setupServer) handleProviders(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unable to retrieve lineups from Gracenote: "+err.Error(), http.StatusBadGateway)
 		return
 	}
+	s.addProviderChannelCounts(r.Context(), country, postalCode, language, result.Providers)
 	sort.SliceStable(result.Providers, func(i, j int) bool {
 		left := providerTypeOrder(result.Providers[i].Type)
 		right := providerTypeOrder(result.Providers[j].Type)
@@ -112,6 +136,57 @@ func (s *setupServer) handleProviders(w http.ResponseWriter, r *http.Request) {
 	})
 	w.Header().Set("Cache-Control", "no-store")
 	writeSetupJSON(w, http.StatusOK, result)
+}
+
+func (s *setupServer) addProviderChannelCounts(ctx context.Context, country, postalCode, language string, providers []web.Provider) {
+	if s.channelCounter == nil || len(providers) == 0 {
+		return
+	}
+	workers := 4
+	if workers > len(providers) {
+		workers = len(providers)
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				count, err := s.channelCounter.CountChannels(ctx, country, postalCode, language, providers[index])
+				if err != nil {
+					log.Printf("Unable to count channels for lineup %s: %v", providers[index].LineupID, err)
+					continue
+				}
+				providers[index].ChannelCount = count
+				providers[index].ChannelCountKnown = true
+			}
+		}()
+	}
+	for index := range providers {
+		select {
+		case jobs <- index:
+		case <-ctx.Done():
+			close(jobs)
+			wg.Wait()
+			return
+		}
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func (s *setupServer) handleScrapeStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.scrapeStatus == nil {
+		writeSetupJSON(w, http.StatusOK, scrapeStatusSnapshot{Stage: "idle", Message: "Guide status is unavailable", UpdatedAt: time.Now().UTC()})
+		return
+	}
+	writeSetupJSON(w, http.StatusOK, s.scrapeStatus.snapshotValue())
 }
 
 func (s *setupServer) handleProvider(w http.ResponseWriter, r *http.Request) {

--- a/setup.go
+++ b/setup.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/daniel-widrick/GraceNoteScraper/appconfig"
+	"github.com/daniel-widrick/GraceNoteScraper/web"
+)
+
+//go:embed setup.html
+var setupFS embed.FS
+
+type providerFinder interface {
+	FindProviders(ctx context.Context, country, postalCode, language string) (*web.ProviderResponse, error)
+}
+
+type setupServer struct {
+	store           *appconfig.Store
+	providers       providerFinder
+	onProviderSaved func(changed bool)
+}
+
+type setupConfigResponse struct {
+	Configured bool                       `json:"configured"`
+	Source     string                     `json:"source,omitempty"`
+	Gracenote  *appconfig.GracenoteConfig `json:"gracenote,omitempty"`
+}
+
+type providerSelection struct {
+	Country    string       `json:"country"`
+	PostalCode string       `json:"postalCode"`
+	Language   string       `json:"language"`
+	Provider   web.Provider `json:"provider"`
+}
+
+func (s *setupServer) handlePage(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/setup" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	data, err := setupFS.ReadFile("setup.html")
+	if err != nil {
+		http.Error(w, "setup page unavailable", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method == http.MethodGet {
+		_, _ = w.Write(data)
+	}
+}
+
+func (s *setupServer) handleConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	config, configured, source := s.store.Get()
+	response := setupConfigResponse{Configured: configured, Source: source}
+	if configured {
+		response.Gracenote = &config.Gracenote
+	}
+	writeSetupJSON(w, http.StatusOK, response)
+}
+
+func (s *setupServer) handleProviders(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	country := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("country")))
+	postalCode := strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("postalCode")))
+	language := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("language")))
+	if country == "" {
+		country = "USA"
+	}
+	if language == "" {
+		language = "en-us"
+	}
+	if err := appconfig.ValidateLookup(country, postalCode, language); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	result, err := s.providers.FindProviders(r.Context(), country, postalCode, language)
+	if err != nil {
+		http.Error(w, "Unable to retrieve lineups from Gracenote: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	sort.SliceStable(result.Providers, func(i, j int) bool {
+		left := providerTypeOrder(result.Providers[i].Type)
+		right := providerTypeOrder(result.Providers[j].Type)
+		if left != right {
+			return left < right
+		}
+		return strings.ToLower(result.Providers[i].Name) < strings.ToLower(result.Providers[j].Name)
+	})
+	w.Header().Set("Cache-Control", "no-store")
+	writeSetupJSON(w, http.StatusOK, result)
+}
+
+func (s *setupServer) handleProvider(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	var selection providerSelection
+	if err := decoder.Decode(&selection); err != nil {
+		http.Error(w, "Invalid provider selection: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		http.Error(w, "Invalid provider selection: request must contain one JSON object", http.StatusBadRequest)
+		return
+	}
+
+	selection.Country = strings.ToUpper(strings.TrimSpace(selection.Country))
+	selection.PostalCode = strings.ToUpper(strings.TrimSpace(selection.PostalCode))
+	selection.Language = strings.ToLower(strings.TrimSpace(selection.Language))
+	if err := appconfig.ValidateLookup(selection.Country, selection.PostalCode, selection.Language); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	config := appconfig.Config{
+		Version: appconfig.CurrentVersion,
+		Gracenote: appconfig.GracenoteConfig{
+			Country:      selection.Country,
+			PostalCode:   selection.PostalCode,
+			Language:     selection.Language,
+			ProviderType: selection.Provider.Type,
+			Device:       selection.Provider.Device,
+			LineupID:     selection.Provider.LineupID,
+			ProviderName: selection.Provider.Name,
+			Location:     selection.Provider.Location,
+			HeadendID:    selection.Provider.HeadendID,
+		},
+	}
+	if err := config.Validate(); err != nil {
+		http.Error(w, "Invalid provider selection: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	oldConfig, wasConfigured, _ := s.store.Get()
+	changed := !wasConfigured || oldConfig.Fingerprint() != config.Fingerprint()
+	if err := s.store.Save(config); err != nil {
+		http.Error(w, fmt.Sprintf("Unable to save provider: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if s.onProviderSaved != nil {
+		s.onProviderSaved(changed)
+	}
+	savedConfig, _, _ := s.store.Get()
+
+	writeSetupJSON(w, http.StatusOK, map[string]any{
+		"configured":   true,
+		"changed":      changed,
+		"scrapeQueued": true,
+		"provider":     savedConfig.Gracenote,
+	})
+}
+
+func providerTypeOrder(providerType string) int {
+	switch strings.ToUpper(providerType) {
+	case "CABLE":
+		return 0
+	case "SATELLITE":
+		return 1
+	case "OTA":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func writeSetupJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(true)
+	_ = encoder.Encode(value)
+}

--- a/setup.html
+++ b/setup.html
@@ -132,8 +132,35 @@
       text-transform: uppercase;
     }
 
+    .current-copy { min-width: 0; }
     .current-name { font-weight: 750; }
     .current-meta { margin-top: 4px; color: var(--muted); font-size: 13px; }
+    .xmltv-url { display: grid; gap: 3px; margin-top: 12px; }
+    .xmltv-url-label {
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
+    .xmltv-url-link {
+      justify-self: start;
+      min-height: 0;
+      padding: 0;
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+      color: var(--accent);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 13px;
+      overflow-wrap: anywhere;
+      text-align: left;
+      text-underline-offset: 3px;
+    }
+    .xmltv-url-link:hover { background: transparent; color: var(--text); text-decoration: underline; }
+    .xmltv-copy-status { min-height: 1.2em; color: var(--muted); font-size: 12px; }
+    .xmltv-copy-status.success { color: var(--accent); }
+    .xmltv-copy-status.error { color: var(--danger); }
     .current-actions { display: flex; align-items: center; gap: 9px; }
 
     .secondary-button {
@@ -366,10 +393,15 @@
     </section>
 
     <section class="current" id="currentCard" aria-live="polite">
-      <div>
+      <div class="current-copy">
         <div class="current-label">Current lineup</div>
         <div class="current-name" id="currentName"></div>
         <div class="current-meta" id="currentMeta"></div>
+        <div class="xmltv-url">
+          <span class="xmltv-url-label">XMLTV guide URL</span>
+          <button class="xmltv-url-link" id="xmltvGuideLink" type="button" title="Copy XMLTV guide URL"></button>
+          <span class="xmltv-copy-status" id="xmltvCopyStatus" aria-live="polite"></span>
+        </div>
       </div>
       <div class="current-actions">
         <button class="secondary-button" id="changeButton" type="button">Change lineup</button>
@@ -423,6 +455,8 @@
       var currentCard = document.getElementById('currentCard');
       var currentName = document.getElementById('currentName');
       var currentMeta = document.getElementById('currentMeta');
+      var xmltvGuideLink = document.getElementById('xmltvGuideLink');
+      var xmltvCopyStatus = document.getElementById('xmltvCopyStatus');
       var changeButton = document.getElementById('changeButton');
       var chooserPanel = document.getElementById('chooserPanel');
       var guideStatus = document.getElementById('guideStatus');
@@ -447,6 +481,57 @@
       var language = 'en-us';
       var configured = false;
       var statusTimer = null;
+
+      var xmltvGuideURL = new URL('/xmlguide.xmltv', window.location.href).href;
+      xmltvGuideLink.textContent = xmltvGuideURL;
+
+      function setXMLTVCopyStatus(text, kind) {
+        xmltvCopyStatus.textContent = text;
+        xmltvCopyStatus.className = 'xmltv-copy-status' + (kind ? ' ' + kind : '');
+      }
+
+      function fallbackCopyXMLTVGuideURL() {
+        var input = document.createElement('textarea');
+        input.value = xmltvGuideURL;
+        input.setAttribute('readonly', '');
+        input.style.position = 'fixed';
+        input.style.opacity = '0';
+        document.body.appendChild(input);
+        input.select();
+        var copied = false;
+        try {
+          copied = document.execCommand('copy');
+        } catch (error) {
+          copied = false;
+        }
+        document.body.removeChild(input);
+        if (!copied) throw new Error('Clipboard unavailable');
+      }
+
+      function copyXMLTVGuideURL() {
+        setXMLTVCopyStatus('Copying…');
+        if (navigator.clipboard && window.isSecureContext) {
+          navigator.clipboard.writeText(xmltvGuideURL)
+            .then(function () { setXMLTVCopyStatus('Copied to clipboard.', 'success'); })
+            .catch(function () {
+              try {
+                fallbackCopyXMLTVGuideURL();
+                setXMLTVCopyStatus('Copied to clipboard.', 'success');
+              } catch (error) {
+                setXMLTVCopyStatus('Could not copy automatically. Select and copy the URL manually.', 'error');
+              }
+            });
+          return;
+        }
+        try {
+          fallbackCopyXMLTVGuideURL();
+          setXMLTVCopyStatus('Copied to clipboard.', 'success');
+        } catch (error) {
+          setXMLTVCopyStatus('Could not copy automatically. Select and copy the URL manually.', 'error');
+        }
+      }
+
+      xmltvGuideLink.addEventListener('click', copyXMLTVGuideURL);
 
       function setMessage(text, kind) {
         message.textContent = text || '';

--- a/setup.html
+++ b/setup.html
@@ -439,7 +439,7 @@
         <div class="step"><span class="step-number">2</span><span>Choose your provider lineup</span></div>
         <div id="providerGroups"></div>
         <div class="save-row" id="saveRow">
-          <div class="save-note">This becomes the active source for the guide and its Lineuparr tools. The first full guide build can take several minutes.</div>
+          <div class="save-note">This becomes the active source for the guide. The first full guide build can take several minutes.</div>
           <button id="saveButton" type="button">Use this lineup</button>
         </div>
       </div>

--- a/setup.html
+++ b/setup.html
@@ -134,6 +134,33 @@
 
     .current-name { font-weight: 750; }
     .current-meta { margin-top: 4px; color: var(--muted); font-size: 13px; }
+    .current-actions { display: flex; align-items: center; gap: 9px; }
+
+    .secondary-button {
+      min-height: 40px;
+      padding: 0 14px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, .035);
+      color: var(--muted);
+    }
+
+    .secondary-button:hover { border-color: var(--accent); background: rgba(255, 255, 255, .055); color: var(--text); }
+
+    .guide-status {
+      display: none;
+      margin: 0 0 20px;
+      padding: 18px 20px;
+      border: 1px solid var(--line);
+      border-radius: 15px;
+      background: rgba(16, 30, 25, .88);
+    }
+
+    .guide-status.show { display: block; }
+    .status-heading { display: flex; justify-content: space-between; gap: 14px; font-weight: 750; }
+    .status-stage { color: var(--accent); }
+    .status-detail { margin-top: 6px; color: var(--muted); font-size: 13px; }
+    .progress-track { overflow: hidden; height: 7px; margin-top: 13px; border-radius: 999px; background: rgba(255, 255, 255, .08); }
+    .progress-fill { width: 0; height: 100%; border-radius: inherit; background: var(--accent); transition: width .25s ease; }
 
     .panel {
       overflow: hidden;
@@ -319,6 +346,7 @@
       .search-area, .results { padding-left: 18px; padding-right: 18px; }
       .search-form { grid-template-columns: 1fr; }
       .current, .save-row { align-items: flex-start; flex-direction: column; }
+      .current-actions { width: 100%; flex-wrap: wrap; }
       .provider-card { grid-template-columns: 22px 1fr; }
       .provider-device { display: none; }
     }
@@ -343,10 +371,19 @@
         <div class="current-name" id="currentName"></div>
         <div class="current-meta" id="currentMeta"></div>
       </div>
-      <a class="guide-link" style="display:inline-block" href="/">View guide</a>
+      <div class="current-actions">
+        <button class="secondary-button" id="changeButton" type="button">Change lineup</button>
+        <a class="guide-link" style="display:inline-block" href="/">View guide</a>
+      </div>
     </section>
 
-    <section class="panel">
+    <section class="guide-status" id="guideStatus" aria-live="polite">
+      <div class="status-heading"><span id="statusMessage">Checking guide status…</span><span class="status-stage" id="statusStage"></span></div>
+      <div class="status-detail" id="statusDetail"></div>
+      <div class="progress-track" id="progressTrack" hidden><div class="progress-fill" id="progressFill"></div></div>
+    </section>
+
+    <section class="panel" id="chooserPanel">
       <div class="search-area">
         <div class="step"><span class="step-number">1</span><span>Find lineups for your area</span></div>
         <form class="search-form" id="searchForm">
@@ -386,6 +423,14 @@
       var currentCard = document.getElementById('currentCard');
       var currentName = document.getElementById('currentName');
       var currentMeta = document.getElementById('currentMeta');
+      var changeButton = document.getElementById('changeButton');
+      var chooserPanel = document.getElementById('chooserPanel');
+      var guideStatus = document.getElementById('guideStatus');
+      var statusMessage = document.getElementById('statusMessage');
+      var statusStage = document.getElementById('statusStage');
+      var statusDetail = document.getElementById('statusDetail');
+      var progressTrack = document.getElementById('progressTrack');
+      var progressFill = document.getElementById('progressFill');
       var guideLink = document.getElementById('guideLink');
       var form = document.getElementById('searchForm');
       var country = document.getElementById('country');
@@ -400,6 +445,8 @@
       var providers = [];
       var selectedIndex = -1;
       var language = 'en-us';
+      var configured = false;
+      var statusTimer = null;
 
       function setMessage(text, kind) {
         message.textContent = text || '';
@@ -419,14 +466,57 @@
         if (provider.location) pieces.push(provider.location);
         if (provider.device === 'L') pieces.push('Digital rebuild');
         else if (provider.device === 'X') pieces.push('Digital');
+        if (provider.channelCountKnown) pieces.push(provider.channelCount.toLocaleString() + ' channels');
         return pieces.join(' · ') || providerTypeLabel(provider.type);
       }
 
       function providerDeviceLabel(provider) {
+        var device;
         if (provider.device === 'L') return 'Rebuild';
         if (provider.device === 'X') return 'Digital';
         if (provider.type === 'OTA') return 'OTA';
-        return provider.type || 'Other';
+        device = provider.type || 'Other';
+        return device;
+      }
+
+      function showConfigured(config) {
+        configured = true;
+        currentName.textContent = config.providerName;
+        currentMeta.textContent = [config.location, config.postalCode, providerTypeLabel(config.providerType)].filter(Boolean).join(' · ');
+        currentCard.style.display = 'flex';
+        guideLink.style.display = 'inline-block';
+        chooserPanel.style.display = 'none';
+        guideStatus.classList.add('show');
+        pollGuideStatus();
+      }
+
+      function renderGuideStatus(status) {
+        var labels = { queued: 'Queued', starting: 'Starting', gracenote: 'Guide download', logos: 'Channel logos', tmdb: 'TMDB enrichment', saving: 'Saving guide', ready: 'Complete', error: 'Needs attention', idle: 'Waiting' };
+        statusMessage.textContent = status.message || 'Guide status unavailable';
+        statusStage.textContent = labels[status.stage] || status.stage || '';
+        var details = [];
+        if (status.channels) details.push(status.channels.toLocaleString() + ' channels');
+        if (status.programs) details.push(status.programs.toLocaleString() + ' programs');
+        statusDetail.textContent = details.join(' · ');
+        var hasProgress = status.running && status.total > 0;
+        progressTrack.hidden = !hasProgress;
+        progressFill.style.width = hasProgress ? Math.max(0, Math.min(100, status.completed * 100 / status.total)) + '%' : '0';
+      }
+
+      function pollGuideStatus() {
+        if (!configured) return;
+        clearTimeout(statusTimer);
+        fetch('/api/setup/status', { cache: 'no-store' })
+          .then(function (response) {
+            if (!response.ok) throw new Error('Unable to read guide status');
+            return response.json();
+          })
+          .then(renderGuideStatus)
+          .catch(function (error) {
+            statusMessage.textContent = error.message;
+            statusStage.textContent = '';
+          })
+          .finally(function () { statusTimer = setTimeout(pollGuideStatus, 2000); });
       }
 
       function loadCurrentConfig() {
@@ -438,10 +528,7 @@
           .then(function (data) {
             if (!data.configured || !data.gracenote) return;
             var config = data.gracenote;
-            currentName.textContent = config.providerName;
-            currentMeta.textContent = [config.location, config.postalCode, providerTypeLabel(config.providerType)].filter(Boolean).join(' · ');
-            currentCard.style.display = 'flex';
-            guideLink.style.display = 'inline-block';
+            showConfigured(config);
             country.value = config.country || 'USA';
             postalCode.value = config.postalCode || '';
             language = config.language || 'en-us';
@@ -535,7 +622,7 @@
         var postal = postalCode.value.trim().toUpperCase();
         if (!postal) return;
 
-        setMessage('Looking up lineups for ' + postal + '…');
+        setMessage('Looking up lineups and channel counts for ' + postal + '…');
         searchButton.disabled = true;
         results.style.display = 'none';
         providers = [];
@@ -589,17 +676,23 @@
             return response.json();
           })
           .then(function (data) {
-            currentName.textContent = data.provider.providerName;
-            currentMeta.textContent = [data.provider.location, data.provider.postalCode, providerTypeLabel(data.provider.providerType)].filter(Boolean).join(' · ');
-            currentCard.style.display = 'flex';
-            guideLink.style.display = 'inline-block';
-            setMessage('Lineup saved. A fresh guide has been queued; the first complete build can take several minutes.', 'success');
+            showConfigured(data.provider);
+            results.style.display = 'none';
+            setMessage('');
             window.scrollTo({ top: 0, behavior: 'smooth' });
           })
           .catch(function (error) {
             setMessage(error.message || 'Unable to save this lineup.', 'error');
           })
           .finally(function () { saveButton.disabled = false; });
+      });
+
+      changeButton.addEventListener('click', function () {
+        chooserPanel.style.display = 'block';
+        results.style.display = 'none';
+        setMessage('Choose another lineup. Your current lineup remains active until you save a replacement.');
+        window.scrollTo({ top: chooserPanel.offsetTop - 20, behavior: 'smooth' });
+        postalCode.focus();
       });
 
       loadCurrentConfig();

--- a/setup.html
+++ b/setup.html
@@ -1,0 +1,609 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GraceNoteScraper setup</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --page: #07110e;
+      --panel: #101e19;
+      --panel-strong: #152720;
+      --line: #2b463b;
+      --text: #f2f7f4;
+      --muted: #a8bbb2;
+      --accent: #7ce6a6;
+      --accent-strong: #4bc77d;
+      --danger: #ff9b94;
+      --warning: #f6d274;
+      --shadow: 0 24px 70px rgba(0, 0, 0, .32);
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at 12% -10%, rgba(75, 199, 125, .18), transparent 35rem),
+        linear-gradient(145deg, #07110e 0%, #0b1512 52%, #08100e 100%);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    a { color: inherit; }
+
+    .shell {
+      width: min(1040px, calc(100% - 32px));
+      margin: 0 auto;
+      padding: 42px 0 70px;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 36px;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 760;
+      letter-spacing: -.02em;
+    }
+
+    .brand-mark {
+      display: grid;
+      width: 42px;
+      height: 42px;
+      place-items: center;
+      border: 1px solid rgba(124, 230, 166, .45);
+      border-radius: 13px;
+      background: linear-gradient(145deg, rgba(124, 230, 166, .22), rgba(124, 230, 166, .05));
+      box-shadow: inset 0 0 20px rgba(124, 230, 166, .08);
+      color: var(--accent);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 18px;
+    }
+
+    .guide-link {
+      display: none;
+      padding: 10px 14px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      color: var(--muted);
+      text-decoration: none;
+    }
+
+    .guide-link:hover { border-color: var(--accent); color: var(--text); }
+
+    .hero {
+      max-width: 760px;
+      margin-bottom: 28px;
+    }
+
+    .eyebrow {
+      margin: 0 0 12px;
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .16em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      max-width: 690px;
+      margin: 0;
+      font-size: clamp(34px, 7vw, 60px);
+      line-height: 1.02;
+      letter-spacing: -.045em;
+    }
+
+    .hero p:last-child {
+      max-width: 650px;
+      margin: 18px 0 0;
+      color: var(--muted);
+      font-size: 17px;
+      line-height: 1.65;
+    }
+
+    .current {
+      display: none;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      margin: 0 0 20px;
+      padding: 18px 20px;
+      border: 1px solid rgba(124, 230, 166, .28);
+      border-radius: 15px;
+      background: rgba(124, 230, 166, .075);
+    }
+
+    .current-label {
+      margin-bottom: 4px;
+      color: var(--accent);
+      font-size: 11px;
+      font-weight: 800;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+
+    .current-name { font-weight: 750; }
+    .current-meta { margin-top: 4px; color: var(--muted); font-size: 13px; }
+
+    .panel {
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 20px;
+      background: rgba(16, 30, 25, .94);
+      box-shadow: var(--shadow);
+    }
+
+    .search-area { padding: 28px; }
+
+    .step {
+      display: flex;
+      align-items: center;
+      gap: 11px;
+      margin-bottom: 18px;
+      font-weight: 730;
+    }
+
+    .step-number {
+      display: grid;
+      width: 29px;
+      height: 29px;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--accent);
+      color: #092015;
+      font-size: 13px;
+      font-weight: 900;
+    }
+
+    .search-form {
+      display: grid;
+      grid-template-columns: minmax(145px, .65fr) minmax(220px, 1.35fr) auto;
+      gap: 13px;
+      align-items: end;
+    }
+
+    label {
+      display: grid;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 13px;
+      font-weight: 650;
+    }
+
+    input, select, button { font: inherit; }
+
+    input, select {
+      width: 100%;
+      height: 48px;
+      padding: 0 14px;
+      border: 1px solid var(--line);
+      border-radius: 11px;
+      outline: none;
+      background: #09130f;
+      color: var(--text);
+    }
+
+    input:focus, select:focus {
+      border-color: var(--accent-strong);
+      box-shadow: 0 0 0 3px rgba(75, 199, 125, .13);
+    }
+
+    button {
+      min-height: 48px;
+      padding: 0 20px;
+      border: 0;
+      border-radius: 11px;
+      background: var(--accent);
+      color: #092015;
+      font-weight: 820;
+      cursor: pointer;
+    }
+
+    button:hover { background: #9af0bb; }
+    button:disabled { cursor: wait; opacity: .58; }
+
+    .message {
+      display: none;
+      margin-top: 16px;
+      padding: 12px 14px;
+      border-radius: 10px;
+      color: var(--muted);
+      background: rgba(255, 255, 255, .04);
+      font-size: 14px;
+      line-height: 1.45;
+    }
+
+    .message.error { color: var(--danger); background: rgba(255, 95, 87, .08); }
+    .message.success { color: var(--accent); background: rgba(124, 230, 166, .08); }
+
+    .results {
+      display: none;
+      padding: 0 28px 28px;
+      border-top: 1px solid var(--line);
+    }
+
+    .results .step { margin-top: 26px; }
+
+    .provider-group + .provider-group { margin-top: 26px; }
+
+    .provider-heading {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 0 0 11px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .13em;
+      text-transform: uppercase;
+    }
+
+    .provider-count {
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, .07);
+      color: var(--muted);
+      font-size: 11px;
+      letter-spacing: 0;
+    }
+
+    .provider-list { display: grid; gap: 9px; }
+
+    .provider-card {
+      display: grid;
+      grid-template-columns: 22px 1fr auto;
+      gap: 13px;
+      align-items: center;
+      min-height: 68px;
+      padding: 14px 16px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(7, 17, 14, .48);
+      cursor: pointer;
+    }
+
+    .provider-card:hover { border-color: #4d6f61; }
+    .provider-card.selected { border-color: var(--accent); background: rgba(124, 230, 166, .075); }
+
+    .provider-card input {
+      width: 18px;
+      height: 18px;
+      margin: 0;
+      accent-color: var(--accent-strong);
+    }
+
+    .provider-name { color: var(--text); font-weight: 720; }
+    .provider-location { margin-top: 3px; color: var(--muted); font-size: 13px; }
+
+    .provider-device {
+      padding: 5px 8px;
+      border-radius: 7px;
+      background: rgba(255, 255, 255, .055);
+      color: var(--muted);
+      font-size: 11px;
+      font-weight: 750;
+    }
+
+    .save-row {
+      display: none;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      margin-top: 24px;
+      padding-top: 20px;
+      border-top: 1px solid var(--line);
+    }
+
+    .save-note { max-width: 570px; color: var(--muted); font-size: 13px; line-height: 1.5; }
+
+    .footnote {
+      margin: 18px 3px 0;
+      color: #789087;
+      font-size: 12px;
+      line-height: 1.55;
+    }
+
+    @media (max-width: 720px) {
+      .shell { width: min(100% - 22px, 1040px); padding-top: 24px; }
+      .topbar { margin-bottom: 28px; }
+      .search-area, .results { padding-left: 18px; padding-right: 18px; }
+      .search-form { grid-template-columns: 1fr; }
+      .current, .save-row { align-items: flex-start; flex-direction: column; }
+      .provider-card { grid-template-columns: 22px 1fr; }
+      .provider-device { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div class="brand"><span class="brand-mark">GN</span><span>GraceNoteScraper</span></div>
+      <a class="guide-link" id="guideLink" href="/">Open guide</a>
+    </header>
+
+    <section class="hero">
+      <p class="eyebrow">Lineup setup</p>
+      <h1>Choose the channels available where you live.</h1>
+      <p>Enter your ZIP or postal code, then choose the cable, satellite, or over-the-air lineup that should power the scraper.</p>
+    </section>
+
+    <section class="current" id="currentCard" aria-live="polite">
+      <div>
+        <div class="current-label">Current lineup</div>
+        <div class="current-name" id="currentName"></div>
+        <div class="current-meta" id="currentMeta"></div>
+      </div>
+      <a class="guide-link" style="display:inline-block" href="/">View guide</a>
+    </section>
+
+    <section class="panel">
+      <div class="search-area">
+        <div class="step"><span class="step-number">1</span><span>Find lineups for your area</span></div>
+        <form class="search-form" id="searchForm">
+          <label>Country
+            <select id="country" name="country">
+              <option value="USA">United States</option>
+              <option value="CAN">Canada</option>
+              <option value="GBR">United Kingdom</option>
+              <option value="AUS">Australia</option>
+            </select>
+          </label>
+          <label>ZIP or postal code
+            <input id="postalCode" name="postalCode" autocomplete="postal-code" inputmode="text" maxlength="16" placeholder="11743" required>
+          </label>
+          <button id="searchButton" type="submit">Find lineups</button>
+        </form>
+        <div class="message" id="message" role="status" aria-live="polite"></div>
+      </div>
+
+      <div class="results" id="results">
+        <div class="step"><span class="step-number">2</span><span>Choose your provider lineup</span></div>
+        <div id="providerGroups"></div>
+        <div class="save-row" id="saveRow">
+          <div class="save-note">This becomes the active source for the guide and its Lineuparr tools. The first full guide build can take several minutes.</div>
+          <button id="saveButton" type="button">Use this lineup</button>
+        </div>
+      </div>
+    </section>
+
+    <p class="footnote">Lineup availability comes from Gracenote's provider directory. GraceNoteScraper stores the selected lineup identifiers locally; this step does not require a provider account or password.</p>
+  </main>
+
+  <script>
+    (function () {
+      'use strict';
+
+      var currentCard = document.getElementById('currentCard');
+      var currentName = document.getElementById('currentName');
+      var currentMeta = document.getElementById('currentMeta');
+      var guideLink = document.getElementById('guideLink');
+      var form = document.getElementById('searchForm');
+      var country = document.getElementById('country');
+      var postalCode = document.getElementById('postalCode');
+      var searchButton = document.getElementById('searchButton');
+      var message = document.getElementById('message');
+      var results = document.getElementById('results');
+      var providerGroups = document.getElementById('providerGroups');
+      var saveRow = document.getElementById('saveRow');
+      var saveButton = document.getElementById('saveButton');
+
+      var providers = [];
+      var selectedIndex = -1;
+      var language = 'en-us';
+
+      function setMessage(text, kind) {
+        message.textContent = text || '';
+        message.className = 'message' + (kind ? ' ' + kind : '');
+        message.style.display = text ? 'block' : 'none';
+      }
+
+      function providerTypeLabel(type) {
+        if (type === 'CABLE') return 'Cable and fiber';
+        if (type === 'SATELLITE') return 'Satellite';
+        if (type === 'OTA') return 'Over the air';
+        return type || 'Other';
+      }
+
+      function providerMeta(provider) {
+        var pieces = [];
+        if (provider.location) pieces.push(provider.location);
+        if (provider.device === 'L') pieces.push('Digital rebuild');
+        else if (provider.device === 'X') pieces.push('Digital');
+        return pieces.join(' · ') || providerTypeLabel(provider.type);
+      }
+
+      function providerDeviceLabel(provider) {
+        if (provider.device === 'L') return 'Rebuild';
+        if (provider.device === 'X') return 'Digital';
+        if (provider.type === 'OTA') return 'OTA';
+        return provider.type || 'Other';
+      }
+
+      function loadCurrentConfig() {
+        fetch('/api/setup/config', { cache: 'no-store' })
+          .then(function (response) {
+            if (!response.ok) throw new Error('Unable to load current setup');
+            return response.json();
+          })
+          .then(function (data) {
+            if (!data.configured || !data.gracenote) return;
+            var config = data.gracenote;
+            currentName.textContent = config.providerName;
+            currentMeta.textContent = [config.location, config.postalCode, providerTypeLabel(config.providerType)].filter(Boolean).join(' · ');
+            currentCard.style.display = 'flex';
+            guideLink.style.display = 'inline-block';
+            country.value = config.country || 'USA';
+            postalCode.value = config.postalCode || '';
+            language = config.language || 'en-us';
+          })
+          .catch(function () {
+            setMessage('The saved setup could not be read. You can choose the lineup again below.', 'error');
+          });
+      }
+
+      function chooseProvider(index) {
+        selectedIndex = index;
+        var cards = providerGroups.querySelectorAll('.provider-card');
+        for (var i = 0; i < cards.length; i++) {
+          var chosen = Number(cards[i].getAttribute('data-index')) === index;
+          cards[i].classList.toggle('selected', chosen);
+          cards[i].querySelector('input').checked = chosen;
+        }
+        saveRow.style.display = 'flex';
+      }
+
+      function renderProviders() {
+        providerGroups.textContent = '';
+        selectedIndex = -1;
+        saveRow.style.display = 'none';
+
+        var grouped = {};
+        providers.forEach(function (provider, index) {
+          var type = provider.type || 'OTHER';
+          if (['CABLE', 'SATELLITE', 'OTA'].indexOf(type) === -1) type = 'OTHER';
+          if (!grouped[type]) grouped[type] = [];
+          grouped[type].push({ provider: provider, index: index });
+        });
+
+        ['CABLE', 'SATELLITE', 'OTA', 'OTHER'].forEach(function (type) {
+          var entries = grouped[type];
+          if (!entries || !entries.length) return;
+
+          var group = document.createElement('section');
+          group.className = 'provider-group';
+
+          var heading = document.createElement('h2');
+          heading.className = 'provider-heading';
+          heading.appendChild(document.createTextNode(providerTypeLabel(type)));
+          var count = document.createElement('span');
+          count.className = 'provider-count';
+          count.textContent = String(entries.length);
+          heading.appendChild(count);
+          group.appendChild(heading);
+
+          var list = document.createElement('div');
+          list.className = 'provider-list';
+          entries.forEach(function (entry) {
+            var card = document.createElement('label');
+            card.className = 'provider-card';
+            card.setAttribute('data-index', String(entry.index));
+
+            var radio = document.createElement('input');
+            radio.type = 'radio';
+            radio.name = 'provider';
+            radio.addEventListener('change', function () { chooseProvider(entry.index); });
+
+            var copy = document.createElement('span');
+            var name = document.createElement('span');
+            name.className = 'provider-name';
+            name.textContent = entry.provider.name;
+            var location = document.createElement('span');
+            location.className = 'provider-location';
+            location.textContent = providerMeta(entry.provider);
+            copy.appendChild(name);
+            copy.appendChild(document.createElement('br'));
+            copy.appendChild(location);
+
+            var device = document.createElement('span');
+            device.className = 'provider-device';
+            device.textContent = providerDeviceLabel(entry.provider);
+
+            card.appendChild(radio);
+            card.appendChild(copy);
+            card.appendChild(device);
+            card.addEventListener('click', function () { chooseProvider(entry.index); });
+            list.appendChild(card);
+          });
+          group.appendChild(list);
+          providerGroups.appendChild(group);
+        });
+        results.style.display = 'block';
+      }
+
+      form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        var postal = postalCode.value.trim().toUpperCase();
+        if (!postal) return;
+
+        setMessage('Looking up lineups for ' + postal + '…');
+        searchButton.disabled = true;
+        results.style.display = 'none';
+        providers = [];
+
+        var query = new URLSearchParams({
+          country: country.value,
+          postalCode: postal,
+          language: language
+        });
+        fetch('/api/setup/providers?' + query.toString(), { cache: 'no-store' })
+          .then(function (response) {
+            if (!response.ok) {
+              return response.text().then(function (text) { throw new Error(text.trim() || 'Lookup failed'); });
+            }
+            return response.json();
+          })
+          .then(function (data) {
+            providers = data.Providers || [];
+            if (!providers.length) {
+              setMessage('No lineups were found for that area. Check the postal code and try again.', 'error');
+              return;
+            }
+            setMessage(providers.length + ' lineup' + (providers.length === 1 ? '' : 's') + ' found.');
+            renderProviders();
+          })
+          .catch(function (error) {
+            setMessage(error.message || 'Unable to retrieve lineups from Gracenote.', 'error');
+          })
+          .finally(function () { searchButton.disabled = false; });
+      });
+
+      saveButton.addEventListener('click', function () {
+        if (selectedIndex < 0 || !providers[selectedIndex]) return;
+        saveButton.disabled = true;
+        setMessage('Saving lineup and preparing a fresh guide…');
+
+        fetch('/api/setup/provider', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            country: country.value,
+            postalCode: postalCode.value.trim().toUpperCase(),
+            language: language,
+            provider: providers[selectedIndex]
+          })
+        })
+          .then(function (response) {
+            if (!response.ok) {
+              return response.text().then(function (text) { throw new Error(text.trim() || 'Save failed'); });
+            }
+            return response.json();
+          })
+          .then(function (data) {
+            currentName.textContent = data.provider.providerName;
+            currentMeta.textContent = [data.provider.location, data.provider.postalCode, providerTypeLabel(data.provider.providerType)].filter(Boolean).join(' · ');
+            currentCard.style.display = 'flex';
+            guideLink.style.display = 'inline-block';
+            setMessage('Lineup saved. A fresh guide has been queued; the first complete build can take several minutes.', 'success');
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          })
+          .catch(function (error) {
+            setMessage(error.message || 'Unable to save this lineup.', 'error');
+          })
+          .finally(function () { saveButton.disabled = false; });
+      });
+
+      loadCurrentConfig();
+    }());
+  </script>
+</body>
+</html>

--- a/setup_test.go
+++ b/setup_test.go
@@ -23,6 +23,16 @@ type fakeProviderFinder struct {
 	language string
 }
 
+type fakeProviderChannelCounter struct {
+	count int
+	calls int
+}
+
+func (f *fakeProviderChannelCounter) CountChannels(_ context.Context, _, _, _ string, _ web.Provider) (int, error) {
+	f.calls++
+	return f.count, nil
+}
+
 func (f *fakeProviderFinder) FindProviders(_ context.Context, country, postalCode, language string) (*web.ProviderResponse, error) {
 	f.country = country
 	f.postal = postalCode
@@ -45,10 +55,12 @@ func TestSetupProviderFlow(t *testing.T) {
 		HeadendID:  "NY67791",
 	}
 	finder := &fakeProviderFinder{response: &web.ProviderResponse{Providers: []web.Provider{provider}}}
+	counter := &fakeProviderChannelCounter{count: 343}
 	callbackCount := 0
 	server := &setupServer{
-		store:     store,
-		providers: finder,
+		store:          store,
+		providers:      finder,
+		channelCounter: counter,
 		onProviderSaved: func(changed bool) {
 			if !changed {
 				t.Error("first save reported unchanged")
@@ -65,6 +77,13 @@ func TestSetupProviderFlow(t *testing.T) {
 	}
 	if finder.country != "USA" || finder.postal != "11743" || finder.language != "en-us" {
 		t.Fatalf("lookup = %q/%q/%q", finder.country, finder.postal, finder.language)
+	}
+	var providerResponse web.ProviderResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &providerResponse); err != nil {
+		t.Fatalf("decoding provider response: %v", err)
+	}
+	if counter.calls != 1 || !providerResponse.Providers[0].ChannelCountKnown || providerResponse.Providers[0].ChannelCount != 343 {
+		t.Fatalf("channel count response = %+v, calls = %d", providerResponse.Providers[0], counter.calls)
 	}
 
 	payload := `{
@@ -129,8 +148,34 @@ func TestSetupPageIsEmbedded(t *testing.T) {
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d", recorder.Code)
 	}
-	if !strings.Contains(recorder.Body.String(), "GraceNoteScraper setup") {
+	body := recorder.Body.String()
+	if !strings.Contains(body, "GraceNoteScraper setup") {
 		t.Fatal("setup page marker not found")
+	}
+	for _, expected := range []string{`id="changeButton"`, `id="guideStatus"`, `id="chooserPanel"`, "channelCountKnown"} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("setup page is missing %q", expected)
+		}
+	}
+}
+
+func TestSetupScrapeStatus(t *testing.T) {
+	status := newScrapeStatus(false, 0, 0)
+	status.start("Starting guide download")
+	status.update("gracenote", "Downloading guide data (3 of 56)", 2, 56, 335, 4100)
+	server := &setupServer{scrapeStatus: status}
+	request := httptest.NewRequest(http.MethodGet, "/api/setup/status", nil)
+	recorder := httptest.NewRecorder()
+	server.handleScrapeStatus(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	var response scrapeStatusSnapshot
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if !response.Running || response.Stage != "gracenote" || response.Completed != 2 || response.Total != 56 || response.Channels != 335 {
+		t.Fatalf("unexpected scrape status: %+v", response)
 	}
 }
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -152,7 +152,7 @@ func TestSetupPageIsEmbedded(t *testing.T) {
 	if !strings.Contains(body, "GraceNoteScraper setup") {
 		t.Fatal("setup page marker not found")
 	}
-	for _, expected := range []string{`id="changeButton"`, `id="guideStatus"`, `id="chooserPanel"`, "channelCountKnown"} {
+	for _, expected := range []string{`id="changeButton"`, `id="guideStatus"`, `id="chooserPanel"`, `id="xmltvGuideLink"`, `id="xmltvCopyStatus"`, "XMLTV guide URL", "new URL('/xmlguide.xmltv', window.location.href)", "navigator.clipboard.writeText(xmltvGuideURL)", "channelCountKnown"} {
 		if !strings.Contains(body, expected) {
 			t.Fatalf("setup page is missing %q", expected)
 		}

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/daniel-widrick/GraceNoteScraper/appconfig"
+	"github.com/daniel-widrick/GraceNoteScraper/guide"
+	"github.com/daniel-widrick/GraceNoteScraper/web"
+)
+
+type fakeProviderFinder struct {
+	response *web.ProviderResponse
+	err      error
+	country  string
+	postal   string
+	language string
+}
+
+func (f *fakeProviderFinder) FindProviders(_ context.Context, country, postalCode, language string) (*web.ProviderResponse, error) {
+	f.country = country
+	f.postal = postalCode
+	f.language = language
+	return f.response, f.err
+}
+
+func TestSetupProviderFlow(t *testing.T) {
+	store, err := appconfig.LoadStore(filepath.Join(t.TempDir(), "config.json"))
+	if err != nil {
+		t.Fatalf("LoadStore() error = %v", err)
+	}
+	provider := web.Provider{
+		Type:       "CABLE",
+		Device:     "X",
+		LineupID:   "USA-NY67791-DEFAULT",
+		Name:       "Verizon Fios - Digital",
+		Location:   "Huntington",
+		PostalCode: "11743",
+		HeadendID:  "NY67791",
+	}
+	finder := &fakeProviderFinder{response: &web.ProviderResponse{Providers: []web.Provider{provider}}}
+	callbackCount := 0
+	server := &setupServer{
+		store:     store,
+		providers: finder,
+		onProviderSaved: func(changed bool) {
+			if !changed {
+				t.Error("first save reported unchanged")
+			}
+			callbackCount++
+		},
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/setup/providers?postalCode=11743", nil)
+	recorder := httptest.NewRecorder()
+	server.handleProviders(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("provider lookup status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if finder.country != "USA" || finder.postal != "11743" || finder.language != "en-us" {
+		t.Fatalf("lookup = %q/%q/%q", finder.country, finder.postal, finder.language)
+	}
+
+	payload := `{
+      "country":"USA",
+      "postalCode":"11743",
+      "language":"en-us",
+      "provider":{
+        "type":"CABLE",
+        "device":"X",
+        "lineupId":"USA-NY67791-DEFAULT",
+        "name":"Verizon Fios - Digital",
+        "location":"Huntington",
+        "timezone":"",
+        "isDefaultProvider":"BLANK",
+        "postalCode":"11743",
+        "headendId":"NY67791"
+      }
+    }`
+	request = httptest.NewRequest(http.MethodPost, "/api/setup/provider", strings.NewReader(payload))
+	request.Header.Set("Content-Type", "application/json")
+	recorder = httptest.NewRecorder()
+	server.handleProvider(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("provider save status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if callbackCount != 1 {
+		t.Fatalf("callback count = %d, want 1", callbackCount)
+	}
+	config, configured, source := store.Get()
+	if !configured || source != "file" || config.Gracenote.LineupID != provider.LineupID {
+		t.Fatalf("saved config = %+v, configured=%v source=%q", config, configured, source)
+	}
+
+	request = httptest.NewRequest(http.MethodGet, "/api/setup/config", nil)
+	recorder = httptest.NewRecorder()
+	server.handleConfig(recorder, request)
+	var response setupConfigResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decoding config response: %v", err)
+	}
+	if !response.Configured || response.Gracenote == nil || response.Gracenote.ProviderName != provider.Name {
+		t.Fatalf("unexpected config response: %+v", response)
+	}
+}
+
+func TestSetupProviderRejectsInvalidContentType(t *testing.T) {
+	store, _ := appconfig.LoadStore(filepath.Join(t.TempDir(), "config.json"))
+	server := &setupServer{store: store}
+	request := httptest.NewRequest(http.MethodPost, "/api/setup/provider", strings.NewReader(`{}`))
+	recorder := httptest.NewRecorder()
+	server.handleProvider(recorder, request)
+	if recorder.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestSetupPageIsEmbedded(t *testing.T) {
+	server := &setupServer{}
+	request := httptest.NewRequest(http.MethodGet, "/setup", nil)
+	recorder := httptest.NewRecorder()
+	server.handlePage(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+	if !strings.Contains(recorder.Body.String(), "GraceNoteScraper setup") {
+		t.Fatal("setup page marker not found")
+	}
+}
+
+func TestGuideRedirectsToSetupUntilConfigured(t *testing.T) {
+	store, _ := appconfig.LoadStore(filepath.Join(t.TempDir(), "config.json"))
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	recorder := httptest.NewRecorder()
+	handleIndex(store)(recorder, request)
+	if recorder.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusSeeOther)
+	}
+	if location := recorder.Header().Get("Location"); location != "/setup" {
+		t.Fatalf("Location = %q, want /setup", location)
+	}
+
+	if err := store.Save(appconfig.Config{
+		Version: appconfig.CurrentVersion,
+		Gracenote: appconfig.GracenoteConfig{
+			Country:      "USA",
+			PostalCode:   "11743",
+			Language:     "en-us",
+			ProviderType: "CABLE",
+			Device:       "X",
+			LineupID:     "USA-NY67791-DEFAULT",
+			ProviderName: "Verizon Fios - Digital",
+			HeadendID:    "NY67791",
+		},
+	}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+	recorder = httptest.NewRecorder()
+	handleIndex(store)(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("configured status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+}
+
+func TestGuideCacheRequiresMatchingSource(t *testing.T) {
+	t.Chdir(t.TempDir())
+	want := &guide.TVGuide{}
+	saveGuideCache(want, "source-one")
+
+	if _, _, ok := loadGuideCache(time.Hour, "source-two"); ok {
+		t.Fatal("cache loaded for a different source")
+	}
+	got, _, ok := loadGuideCache(time.Hour, "source-one")
+	if !ok || got == nil {
+		t.Fatal("cache did not load for matching source")
+	}
+}

--- a/web/providers.go
+++ b/web/providers.go
@@ -24,6 +24,8 @@ type Provider struct {
 	IsDefaultProvider string `json:"isDefaultProvider"`
 	PostalCode        string `json:"postalCode"`
 	HeadendID         string `json:"headendId"`
+	ChannelCount      int    `json:"channelCount,omitempty"`
+	ChannelCountKnown bool   `json:"channelCountKnown,omitempty"`
 }
 
 // ProviderResponse is the public provider-discovery response used by the

--- a/web/providers.go
+++ b/web/providers.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const providerBaseURL = "https://tvlistings.gracenote.com/gapzap_webapi/api"
+
+// Provider describes one Gracenote lineup returned for a postal code.
+type Provider struct {
+	Type              string `json:"type"`
+	Device            string `json:"device"`
+	LineupID          string `json:"lineupId"`
+	Name              string `json:"name"`
+	Location          string `json:"location"`
+	Timezone          string `json:"timezone"`
+	IsDefaultProvider string `json:"isDefaultProvider"`
+	PostalCode        string `json:"postalCode"`
+	HeadendID         string `json:"headendId"`
+}
+
+// ProviderResponse is the public provider-discovery response used by the
+// Gracenote listings website.
+type ProviderResponse struct {
+	DSTUTCOffset string     `json:"DSTUTCOffset"`
+	StdUTCOffset string     `json:"StdUTCOffset"`
+	DSTEnd       string     `json:"DSTEnd"`
+	DSTStart     string     `json:"DSTStart"`
+	PrimeTime    string     `json:"primetime"`
+	Providers    []Provider `json:"Providers"`
+}
+
+// ProviderClient retrieves the lineups available for a postal code.
+type ProviderClient struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+func NewProviderClient() *ProviderClient {
+	return &ProviderClient{
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		baseURL:    providerBaseURL,
+	}
+}
+
+func newProviderClient(httpClient *http.Client, baseURL string) *ProviderClient {
+	return &ProviderClient{httpClient: httpClient, baseURL: strings.TrimRight(baseURL, "/")}
+}
+
+func (c *ProviderClient) FindProviders(ctx context.Context, country, postalCode, language string) (*ProviderResponse, error) {
+	endpoint, err := url.JoinPath(
+		c.baseURL,
+		"Providers",
+		"getPostalCodeProviders",
+		strings.ToUpper(country),
+		strings.ToUpper(postalCode),
+		"gapzap",
+		strings.ToLower(language),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("building provider lookup URL: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building provider lookup request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Referer", "https://tvlistings.gracenote.com/grid-affiliates.html?aid=gapzap")
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("provider lookup failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("provider lookup returned %s", resp.Status)
+	}
+
+	var result ProviderResponse
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, 2<<20))
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding provider lookup: %w", err)
+	}
+	if result.Providers == nil {
+		result.Providers = []Provider{}
+	}
+	return &result, nil
+}

--- a/web/providers_test.go
+++ b/web/providers_test.go
@@ -1,0 +1,61 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestProviderClientFindProviders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wantPath := "/Providers/getPostalCodeProviders/USA/11743/gapzap/en-us"
+		if r.URL.Path != wantPath {
+			t.Fatalf("path = %q, want %q", r.URL.Path, wantPath)
+		}
+		if got := r.Header.Get("X-Requested-With"); got != "XMLHttpRequest" {
+			t.Fatalf("X-Requested-With = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+          "DSTUTCOffset":"-240",
+          "Providers":[{
+            "type":"CABLE",
+            "device":"X",
+            "lineupId":"USA-NY67791-DEFAULT",
+            "name":"Verizon Fios - Digital",
+            "location":"Huntington",
+            "postalCode":"11743",
+            "headendId":"NY67791"
+          }]
+        }`))
+	}))
+	defer server.Close()
+
+	client := newProviderClient(server.Client(), server.URL)
+	result, err := client.FindProviders(context.Background(), "usa", "11743", "EN-US")
+	if err != nil {
+		t.Fatalf("FindProviders() error = %v", err)
+	}
+	if len(result.Providers) != 1 {
+		t.Fatalf("provider count = %d, want 1", len(result.Providers))
+	}
+	provider := result.Providers[0]
+	if provider.LineupID != "USA-NY67791-DEFAULT" || provider.HeadendID != "NY67791" {
+		t.Fatalf("unexpected provider: %+v", provider)
+	}
+}
+
+func TestProviderClientRejectsNonSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "blocked", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := newProviderClient(server.Client(), server.URL)
+	_, err := client.FindProviders(context.Background(), "USA", "11743", "en-us")
+	if err == nil || !strings.Contains(err.Error(), "403") {
+		t.Fatalf("FindProviders() error = %v, want status error", err)
+	}
+}

--- a/web/web.go
+++ b/web/web.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -64,6 +65,10 @@ type Client struct {
 }
 
 func (c *Client) GetDataByTime(t int64) (*GridResponse, error) {
+	return c.GetDataByTimeContext(context.Background(), t)
+}
+
+func (c *Client) GetDataByTimeContext(ctx context.Context, t int64) (*GridResponse, error) {
 	log.Printf("headendId=%s lineupId=%s zipCode=%s", c.pref.Headend, c.pref.LineupId, c.pref.ZipCode)
 
 	params := url.Values{
@@ -83,7 +88,7 @@ func (c *Client) GetDataByTime(t int64) (*GridResponse, error) {
 	}
 	gridURL := "https://tvlistings.gracenote.com/api/grid?" + params.Encode()
 	log.Printf("Fetching: %s", gridURL)
-	req, err := http.NewRequest("GET", gridURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gridURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("GetDataByTime failed to build request: %w", err)
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -9,8 +9,6 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"time"
-
-	"github.com/daniel-widrick/GraceNoteScraper/util"
 )
 
 const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.47 Safari/537.36"
@@ -109,7 +107,7 @@ func (c *Client) GetDataByTime(t int64) (*GridResponse, error) {
 	return &grid, nil
 }
 
-func NewClient() *Client {
+func NewClient(pref Preferences) *Client {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
 		log.Fatalf("Unable to create cookie storage for http client: %v", err)
@@ -123,14 +121,7 @@ func NewClient() *Client {
 				rt: http.DefaultTransport,
 			},
 		},
-		pref: Preferences{
-			Country:  util.GetEnv("GN_COUNTRY", "USA"),
-			ZipCode:  util.GetEnv("GN_ZIPCODE", "13490"),
-			Headend:  util.GetEnv("GN_HEADEND", "lineupId"),
-			LineupId: util.GetEnv("GN_LINEUP", "USA-lineupId-DEFAULT"),
-			Device:   util.GetEnv("GN_DEVICE", "-"),
-			Language: util.GetEnv("GN_LANGUAGE", "en-us"),
-		},
+		pref: pref,
 	}
 }
 


### PR DESCRIPTION
Adds `/setup` so users can find and select a Gracenote lineup by country and ZIP/postal code. The server starts before a guide exists, and `/` redirects to setup until a provider is configured.

- Group cable, satellite, and over-the-air lineups and show channel counts when available. Once selected, collapse the chooser behind **Change lineup**.
- Persist the selected source in `config.json` (configurable through `CONFIG_PATH`), queue a guide build, and show download, logo, TMDB, and save progress.
- Scope guide caches and publication to the selected source so a previous lineup's scrape cannot publish after the source changes. Return HTTP 503 with `Retry-After` while the initial guide is unavailable.
- Display the browser-reachable XMLTV URL with click-to-copy behavior, including a fallback for local HTTP browsers.

Complete legacy `GN_*` settings remain supported when no saved configuration exists; a saved selection takes precedence. Existing guide caches without a matching source fingerprint are rebuilt. `--guide-only` requires either a saved lineup or complete environment configuration.

Validation: Go 1.25.0 tests, race tests, vet, module verification, formatting, native build, embedded JavaScript syntax checks, and CGO-disabled trimmed builds for Linux amd64/arm64 and Windows amd64.

Integration note: this PR works independently against upstream `main` and neither requires nor includes #12. The two PRs have a small merge conflict in `web/web.go`, so whichever merges second may need a few adjustments to preserve both changes. I can make those adjustments and handle any cleanup after either PR is merged.
